### PR TITLE
Introduced AuthMethod and refactored

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,10 +1,11 @@
 package osin
 
-type ClientType string
+type AuthMethod string
 
 const (
-	PUBLIC_CLIENT 		ClientType 	= "public"
-	CONFIDENTIAL_CLIENT  			= "confidential"
+	NONE                AuthMethod = "none" // The client is public
+	CLIENT_SECRET_BASIC AuthMethod = "client_secret_basic"
+	CLIENT_SECRET_POST  AuthMethod = "client_secret_post"
 )
 
 // Client information
@@ -14,9 +15,9 @@ type Client interface {
 
 	// Client secret
 	GetSecret() string
-	
-	// Client type
-	GetType() ClientType
+
+	// Authentication Method
+	GetAuthMethod() AuthMethod
 
 	// Base client uri
 	GetRedirectUri() string
@@ -29,7 +30,7 @@ type Client interface {
 type DefaultClient struct {
 	Id          string
 	Secret      string
-	Type        ClientType
+	AuthMethod  AuthMethod
 	RedirectUri string
 	UserData    interface{}
 }
@@ -42,8 +43,8 @@ func (d *DefaultClient) GetSecret() string {
 	return d.Secret
 }
 
-func (d *DefaultClient) GetType() ClientType {
-	return d.Type
+func (d *DefaultClient) GetAuthMethod() AuthMethod {
+	return d.AuthMethod
 }
 
 func (d *DefaultClient) GetRedirectUri() string {

--- a/client.go
+++ b/client.go
@@ -1,5 +1,12 @@
 package osin
 
+type ClientType string
+
+const (
+	PUBLIC_CLIENT 		ClientType 	= "public"
+	CONFIDENTIAL_CLIENT  			= "confidential"
+)
+
 // Client information
 type Client interface {
 	// Client id
@@ -7,6 +14,9 @@ type Client interface {
 
 	// Client secret
 	GetSecret() string
+	
+	// Client type
+	GetType() ClientType
 
 	// Base client uri
 	GetRedirectUri() string
@@ -19,6 +29,7 @@ type Client interface {
 type DefaultClient struct {
 	Id          string
 	Secret      string
+	Type        ClientType
 	RedirectUri string
 	UserData    interface{}
 }
@@ -29,6 +40,10 @@ func (d *DefaultClient) GetId() string {
 
 func (d *DefaultClient) GetSecret() string {
 	return d.Secret
+}
+
+func (d *DefaultClient) GetType() ClientType {
+	return d.Type
 }
 
 func (d *DefaultClient) GetRedirectUri() string {

--- a/clientauthenticate.go
+++ b/clientauthenticate.go
@@ -1,0 +1,131 @@
+package osin
+
+import (
+	"errors"
+	"net/http"
+)
+
+type ClientAuthenticationResult struct {
+	Client	        Client
+	CanProceed		bool
+	Error			string
+	InternalError	error
+}
+
+func authenticateClient(s Storage, r *http.Request, allowSecretInParams bool, grantType string) *ClientAuthenticationResult {
+		
+	basicAuth, basicAuthErr := CheckBasicAuth(r)
+	
+	paramsClientId, paramsClientSecret:= getParamsClient(r)
+	
+	if basicAuth == nil && allowSecretInParams == false && paramsClientSecret != nil { 
+		return invalidRequest(errors.New("Client authentication not sent"))
+	}
+	
+	if basicAuthErr != nil && paramsClientId == nil && paramsClientSecret == nil {
+		return invalidRequest(basicAuthErr)
+	}
+	
+	
+	clientId := ""
+	clientSecret := ""
+	
+	if basicAuth != nil {
+		clientId 		= basicAuth.Username
+		clientSecret 	= basicAuth.Password
+	} else {
+	    if paramsClientId != nil { clientId = *paramsClientId}
+		if paramsClientSecret != nil { clientSecret = *paramsClientSecret}
+	}
+	
+	if clientId == "" { 
+		return invalidRequest(errors.New("Client authentication not sent"))
+		}
+	clientSecretSupplied := clientSecret != ""
+	
+	client, err := s.GetClient(clientId)
+	if err != nil {
+		return serverError(err)
+	}
+	
+	if client == nil {
+		return unauthorizedClient(nil)
+	}
+	
+	if client.GetRedirectUri() == "" {
+		return unauthorizedClient(nil)
+	}
+	
+	grantTypeRequiresSecret := grantTypeRequiresSecret(grantType)
+	
+	mustAuthenticateWithSecret := grantTypeRequiresSecret ||
+								  (!grantTypeRequiresSecret && client.GetType() == CONFIDENTIAL_CLIENT) ||
+								  (!grantTypeRequiresSecret && client.GetSecret() != "") ||
+								  (!grantTypeRequiresSecret && clientSecretSupplied)
+								
+	
+	if !mustAuthenticateWithSecret {
+		return canProceed(client)
+	}
+	
+	if client.GetSecret() != clientSecret {
+		return unauthorizedClient(nil)
+	} else {
+		return canProceed(client)
+	}
+	
+	
+}
+
+func grantTypeRequiresSecret(grantType string) bool {
+	switch grantType{
+		case PASSWORD, REFRESH_TOKEN, string(AUTHORIZATION_CODE):
+			return false
+		default:
+			return true	
+	}
+}
+
+
+func invalidRequest(internalError error) *ClientAuthenticationResult {
+	return &ClientAuthenticationResult{ 
+		CanProceed : false, 
+		Error : E_INVALID_REQUEST,
+		InternalError : internalError}
+}
+
+func serverError(internalError error) *ClientAuthenticationResult {
+	return &ClientAuthenticationResult{ 
+		CanProceed : false, 
+		Error : E_SERVER_ERROR,
+		InternalError : internalError}
+}
+
+func unauthorizedClient(internalError error) *ClientAuthenticationResult {
+	return &ClientAuthenticationResult{ 
+		CanProceed : false, 
+		Error : E_UNAUTHORIZED_CLIENT,
+		InternalError : internalError}
+}
+
+func canProceed(client Client) *ClientAuthenticationResult {
+	return &ClientAuthenticationResult{ 
+		CanProceed : true, 
+		Client: client,
+	}
+}
+
+func getParamsClient(r *http.Request) (*string, *string) {
+	var client_id *string
+	if _, hasClientId := r.Form["client_id"]; hasClientId {
+		client_id_val := r.Form.Get("client_id")
+		client_id = &client_id_val
+	}
+	
+	if _, hasClientSecret := r.Form["client_secret"]; hasClientSecret {
+		client_secret_val := r.Form.Get("client_secret")
+		return client_id, &client_secret_val
+	}
+	return client_id, nil
+	
+}

--- a/clientauthenticate.go
+++ b/clientauthenticate.go
@@ -6,120 +6,110 @@ import (
 )
 
 type ClientAuthenticationResult struct {
-	Client	        Client
-	CanProceed		bool
-	Error			string
-	InternalError	error
+	Client        Client
+	CanProceed    bool
+	Error         string
+	InternalError error
+	MustReturn401 bool
 }
 
-func authenticateClient(s Storage, r *http.Request, allowSecretInParams bool, grantType string) *ClientAuthenticationResult {
-		
-	basicAuth, basicAuthErr := CheckBasicAuth(r)
-	
-	paramsClientId, paramsClientSecret:= getParamsClient(r)
-	
-	if basicAuth == nil && allowSecretInParams == false && paramsClientSecret != nil { 
-		return invalidRequest(errors.New("Client authentication not sent"))
-	}
-	
+func authenticateClient(s Storage, r *http.Request, grantType string) *ClientAuthenticationResult {
+
+	basicAuth, authHeaderFound, basicAuthErr := CheckBasicAuth(r)
+
+	paramsClientId, paramsClientSecret := getParamsClient(r)
+
 	if basicAuthErr != nil && paramsClientId == nil && paramsClientSecret == nil {
-		return invalidRequest(basicAuthErr)
+		return canNotProceed(E_INVALID_CLIENT, basicAuthErr, authHeaderFound)
 	}
-	
-	
+
 	clientId := ""
 	clientSecret := ""
 	var basicAuthIsComplete bool
 	var formParmsIsComplete bool
+
 	if basicAuth != nil {
-		clientId 		= basicAuth.Username
-		clientSecret 	= basicAuth.Password
+		clientId = basicAuth.Username
+		clientSecret = basicAuth.Password
 		basicAuthIsComplete = (basicAuth.Username != "" && basicAuth.Password != "")
 	} else {
-	    if paramsClientId != nil { clientId = *paramsClientId}
-		if paramsClientSecret != nil { clientSecret = *paramsClientSecret}
+		if paramsClientId != nil {
+			clientId = *paramsClientId
+		}
+		if paramsClientSecret != nil {
+			clientSecret = *paramsClientSecret
+		}
 		formParmsIsComplete = (clientId != "" && clientSecret != "")
 	}
-	
-	if clientId == "" { 
-		return invalidRequest(errors.New("Client authentication not sent"))
+
+	if clientId == "" {
+		return canNotProceed(E_INVALID_CLIENT, errors.New("Client authentication not sent"), authHeaderFound)
 	}
 	clientSecretSupplied := clientSecret != ""
-	
+
 	client, err := s.GetClient(clientId)
 	if err != nil {
-		return serverError(err)
+		return canNotProceed(E_SERVER_ERROR, err, authHeaderFound)
 	}
-	
+
 	if client == nil {
-		return unauthorizedClient(nil)
+		return canNotProceed(E_INVALID_CLIENT, nil, authHeaderFound)
 	}
-	
+
 	if (client.GetAuthMethod() == CLIENT_SECRET_BASIC && !basicAuthIsComplete) ||
-	   (client.GetAuthMethod() == CLIENT_SECRET_POST  && !formParmsIsComplete) {
-		return invalidRequest(errors.New("Client authentication not sent"))
+		(client.GetAuthMethod() == CLIENT_SECRET_POST && !formParmsIsComplete) {
+
+		return canNotProceed(E_INVALID_CLIENT, errors.New("Client authentication not sent"), authHeaderFound)
 	}
-	
+
 	if client.GetRedirectUri() == "" {
-		return unauthorizedClient(nil)
+		return canNotProceed(E_INVALID_CLIENT, errors.New("Client authentication not sent"), authHeaderFound)
 	}
-	
+
 	grantTypeRequiresSecret := grantTypeRequiresSecret(grantType)
-	
+
 	mustAuthenticateWithSecret := grantTypeRequiresSecret ||
-								  (!grantTypeRequiresSecret && client.GetAuthMethod() != NONE) ||
-								  (!grantTypeRequiresSecret && client.GetSecret() != "") ||
-								  (!grantTypeRequiresSecret && clientSecretSupplied)
-								
-	
+		(!grantTypeRequiresSecret && client.GetAuthMethod() != NONE) ||
+		(!grantTypeRequiresSecret && client.GetSecret() != "") ||
+		(!grantTypeRequiresSecret && clientSecretSupplied)
+
 	if !mustAuthenticateWithSecret {
 		return canProceed(client)
 	}
-	
+
 	if client.GetSecret() != clientSecret {
-		return unauthorizedClient(nil)
+		return canNotProceed(E_INVALID_CLIENT, nil, authHeaderFound)
 	} else {
 		return canProceed(client)
 	}
-	
-	
+
 }
 
 func grantTypeRequiresSecret(grantType string) bool {
-	switch grantType{
-		case PASSWORD, REFRESH_TOKEN, string(AUTHORIZATION_CODE):
-			return false
-		default:
-			return true	
+	switch grantType {
+	case PASSWORD, REFRESH_TOKEN, string(AUTHORIZATION_CODE):
+		return false
+	default:
+		return true
 	}
 }
 
-
-func invalidRequest(internalError error) *ClientAuthenticationResult {
-	return &ClientAuthenticationResult{ 
-		CanProceed : false, 
-		Error : E_INVALID_REQUEST,
-		InternalError : internalError}
-}
-
-func serverError(internalError error) *ClientAuthenticationResult {
-	return &ClientAuthenticationResult{ 
-		CanProceed : false, 
-		Error : E_SERVER_ERROR,
-		InternalError : internalError}
-}
-
-func unauthorizedClient(internalError error) *ClientAuthenticationResult {
-	return &ClientAuthenticationResult{ 
-		CanProceed : false, 
-		Error : E_UNAUTHORIZED_CLIENT,
-		InternalError : internalError}
+func canNotProceed(errString string, internalError error, authHeaderFound bool) *ClientAuthenticationResult {
+	var mustReturn401 bool
+	if authHeaderFound {
+		mustReturn401 = true
+	}
+	return &ClientAuthenticationResult{
+		CanProceed:    false,
+		Error:         errString,
+		InternalError: internalError,
+		MustReturn401: mustReturn401}
 }
 
 func canProceed(client Client) *ClientAuthenticationResult {
-	return &ClientAuthenticationResult{ 
-		CanProceed : true, 
-		Client: client,
+	return &ClientAuthenticationResult{
+		CanProceed: true,
+		Client:     client,
 	}
 }
 
@@ -129,11 +119,11 @@ func getParamsClient(r *http.Request) (*string, *string) {
 		client_id_val := r.Form.Get("client_id")
 		client_id = &client_id_val
 	}
-	
+
 	if _, hasClientSecret := r.Form["client_secret"]; hasClientSecret {
 		client_secret_val := r.Form.Get("client_secret")
 		return client_id, &client_secret_val
 	}
 	return client_id, nil
-	
+
 }

--- a/clientauthenticate_client_credentials_grant_type_test.go
+++ b/clientauthenticate_client_credentials_grant_type_test.go
@@ -36,82 +36,86 @@ func TestAuthenticateClient_other_grant_types(t *testing.T) {
 	proceed_not_expected := false;
 
 	var tests = []struct {
+		id                      int
 		header           		*AuthHeader
 		param_client_id	     	*string
 		param_client_secret    	*string
 		clientIsInStorage		bool
 		storedClientSecret		string
-		storedClientType		ClientType
+		storedAuthMethod		AuthMethod
 		allowQueryParams 		bool
 		canProceed       		bool
 		returnedError			string
 		
 	}{
-	{headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected,     NO_ERROR},
-	{headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 	     CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, param_id("123"), param_secret(""),	      in_storage,     "", 		 CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected,     NO_ERROR},
-	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected,     NO_ERROR},
-	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	     CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, 	  E_UNAUTHORIZED_CLIENT},
+	{1, headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
+	{2, headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected,     E_INVALID_REQUEST},
+	{231,headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	proceed_expected, 	   NO_ERROR},
+	{3, headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 	     CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{4, headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{5, headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{6, headerNoAuth, param_id("123"), param_secret(""),	      in_storage,     "", 		 CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected,     E_INVALID_REQUEST},
+	{7, headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected,     E_INVALID_REQUEST},
+	{8, headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{9, headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{10,headerNoAuth, no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	     CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{11,headerNoAuth, param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
 	
-	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 PUBLIC_CLIENT	   ,  disallow_params, proceed_expected, 	   NO_ERROR},
-	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	   NO_ERROR},
-	{headerNoAuth, param_id("123"), no_param_secret(),      not_in_storage, "", 		 PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 		 PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, no_param_id()  , no_param_secret(),      not_in_storage, "", 	     PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "", 		 PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	   NO_ERROR},
-	{headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, param_id("noredirect"), no_param_secret(), in_storage,     "",     PUBLIC_CLIENT    ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{12,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 NONE	   ,  disallow_params, proceed_expected, 	   NO_ERROR},
+	{13,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 NONE	   ,  allow_params, 	proceed_expected, 	   NO_ERROR},
+	{14,headerNoAuth, param_id("123"), no_param_secret(),      not_in_storage, "", 		 NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{15,headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 		 NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{16,headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{17,headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{18,headerNoAuth, no_param_id()  , no_param_secret(),      not_in_storage, "", 	     NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{19,headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "", 		 NONE	   ,  allow_params, 	proceed_expected, 	   NO_ERROR},
+	{20,headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{21,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{22,headerNoAuth, param_id("noredirect"), no_param_secret(), in_storage,     "",     NONE    ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
 	
-	{headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params,  proceed_not_expected, E_INVALID_REQUEST},
-	{headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	   NO_ERROR},
-	{headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",       CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "", 	  CONFIDENTIAL_CLIENT,  allow_params, 	    proceed_expected, 	   NO_ERROR},
-	{headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "", 	  CONFIDENTIAL_CLIENT,  allow_params, 	    proceed_expected, 	   NO_ERROR},
-	{headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",       CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",       CONFIDENTIAL_CLIENT,  allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
+	{22,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params,  proceed_not_expected, E_INVALID_REQUEST},
+	{23,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	   E_INVALID_REQUEST},
+	{230,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	proceed_expected, 	   NO_ERROR},
+	{24,headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",       CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{25,headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{26,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
+	{27,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "", 	  CLIENT_SECRET_BASIC,  allow_params, 	    proceed_not_expected, 	   E_INVALID_REQUEST},
+	{28,headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "", 	  CLIENT_SECRET_BASIC,  allow_params, 	    proceed_not_expected, 	   E_INVALID_REQUEST},
+	{29,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{30,headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",       CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{31,headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",       CLIENT_SECRET_BASIC,  allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
 	
-	{headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        PUBLIC_CLIENT	   , disallow_params, 	proceed_expected, 	   NO_ERROR},
-	{headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        PUBLIC_CLIENT	   , allow_params,     proceed_expected, 	   NO_ERROR},
-	{headerBadAuth, param_id("123"), no_param_secret(),      not_in_storage, "",        PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",        PUBLIC_CLIENT	   , allow_params,     proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret",  PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",        PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
-	{headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",        PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
-	{headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "",        PUBLIC_CLIENT	   , allow_params, 	    proceed_expected, 	   NO_ERROR},
-	{headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret",  PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "secret",  PUBLIC_CLIENT	   , allow_params,     proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{32,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        NONE	   , disallow_params, 	proceed_expected, 	   NO_ERROR},
+	{33,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        NONE	   , allow_params,     proceed_expected, 	   NO_ERROR},
+	{34,headerBadAuth, param_id("123"), no_param_secret(),      not_in_storage, "",        NONE	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{35,headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",        NONE	   , allow_params,     proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{36,headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret",  NONE	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{37,headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",        NONE	   , allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
+	{38,headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",        NONE	   , allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
+	{39,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "",        NONE	   , allow_params, 	    proceed_expected, 	   NO_ERROR},
+	{40,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret",  NONE	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{41,headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "secret",  NONE	   , allow_params,     proceed_not_expected, E_UNAUTHORIZED_CLIENT},
 	
 	
-	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params,  proceed_expected,     NO_ERROR},
-	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected,     NO_ERROR},
-	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage, "", 	   CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 	 "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 	 "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage,     "", 	   CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage, "", 	   CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage, "", 	   CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{42,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params,  proceed_expected,     NO_ERROR},
+	{43,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_expected,     NO_ERROR},
+	{430,headerOKAuth("", ""),         param_id("123"), param_secret("secret"),in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	  proceed_not_expected,     E_INVALID_REQUEST},
+	{44,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{45,headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 	 "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{46,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 	 "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{47,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage,     "", 	   CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, 	 E_INVALID_REQUEST},
+	{48,headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{49,headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
 	
-	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", PUBLIC_CLIENT,  		disallow_params, proceed_expected, 	 NO_ERROR},
-	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage,   "", 	      PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 		"secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage,	"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage,	"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{headerOKAuth("noredirect", "secret"), no_param_id(), no_param_secret(), in_storage, "secret",PUBLIC_CLIENT,       allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{50,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", NONE,  		disallow_params, proceed_expected, 	 NO_ERROR},
+	{51,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", NONE,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{52,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage,   "", 	      NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{53,headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{54,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{55,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"", 	  NONE,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{56,headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{57,headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{58,headerOKAuth("noredirect", "secret"), no_param_id(), no_param_secret(), in_storage, "secret",NONE,       allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
 
 	}
 
@@ -141,7 +145,7 @@ func TestAuthenticateClient_other_grant_types(t *testing.T) {
 				Id:          *client_id,
 				Secret:      tt.storedClientSecret,
 				RedirectUri: redirectUri,
-				Type: tt.storedClientType,
+				AuthMethod: tt.storedAuthMethod,
 			}
 		}
 		
@@ -172,7 +176,7 @@ func TestAuthenticateClient_other_grant_types(t *testing.T) {
 		}
 		
 		if tt.returnedError != result.Error {
-			t.Errorf("Expected error '%v' but was '%v'", tt.returnedError, result.Error)
+			t.Errorf("Expected error '%v' but was '%v',  %v", tt.returnedError, result.Error, tt)
 		}
 	}
 

--- a/clientauthenticate_client_credentials_grant_type_test.go
+++ b/clientauthenticate_client_credentials_grant_type_test.go
@@ -30,8 +30,6 @@ func TestAuthenticateClient_other_grant_types(t *testing.T) {
 	param_id := func(value string) *string {return &value}
 	in_storage := true;
 	not_in_storage := false;
-	allow_params := true;
-	disallow_params := false;
 	proceed_expected := true;
 	proceed_not_expected := false;
 
@@ -43,79 +41,78 @@ func TestAuthenticateClient_other_grant_types(t *testing.T) {
 		clientIsInStorage		bool
 		storedClientSecret		string
 		storedAuthMethod		AuthMethod
-		allowQueryParams 		bool
 		canProceed       		bool
 		returnedError			string
 		
 	}{
-	{1, headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
-	{2, headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected,     E_INVALID_REQUEST},
-	{231,headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	proceed_expected, 	   NO_ERROR},
-	{3, headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 	     CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{4, headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{5, headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{6, headerNoAuth, param_id("123"), param_secret(""),	      in_storage,     "", 		 CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected,     E_INVALID_REQUEST},
-	{7, headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected,     E_INVALID_REQUEST},
-	{8, headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{9, headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{10,headerNoAuth, no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	     CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{11,headerNoAuth, param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
+	{1, headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,   proceed_not_expected, E_INVALID_CLIENT},
+	{2, headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	  proceed_not_expected,     E_INVALID_CLIENT},
+	{231,headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,   	proceed_expected, 	   NO_ERROR},
+	{3, headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 	     CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{4, headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{5, headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{6, headerNoAuth, param_id("123"), param_secret(""),	      in_storage,     "", 		 CLIENT_SECRET_BASIC,   	  proceed_not_expected,     E_INVALID_CLIENT},
+	{7, headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 CLIENT_SECRET_BASIC,   	  proceed_not_expected,     E_INVALID_CLIENT},
+	{8, headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{9, headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{10,headerNoAuth, no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	     CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{11,headerNoAuth, param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, 	  E_INVALID_CLIENT},
 	
-	{12,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 NONE	   ,  disallow_params, proceed_expected, 	   NO_ERROR},
-	{13,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 NONE	   ,  allow_params, 	proceed_expected, 	   NO_ERROR},
-	{14,headerNoAuth, param_id("123"), no_param_secret(),      not_in_storage, "", 		 NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{15,headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 		 NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{16,headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{17,headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{18,headerNoAuth, no_param_id()  , no_param_secret(),      not_in_storage, "", 	     NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{19,headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "", 		 NONE	   ,  allow_params, 	proceed_expected, 	   NO_ERROR},
-	{20,headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{21,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{22,headerNoAuth, param_id("noredirect"), no_param_secret(), in_storage,     "",     NONE    ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{12,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 NONE	   ,   proceed_expected, 	   NO_ERROR},
+	{13,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 NONE	   ,   	proceed_expected, 	   NO_ERROR},
+	{14,headerNoAuth, param_id("123"), no_param_secret(),      not_in_storage, "", 		 NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT},
+	{15,headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 		 NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT},
+	{16,headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT},
+	{17,headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT},
+	{18,headerNoAuth, no_param_id()  , no_param_secret(),      not_in_storage, "", 	     NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT},
+	{19,headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "", 		 NONE	   ,   	proceed_expected, 	   NO_ERROR},
+	{20,headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT},
+	{21,headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT},
+	{22,headerNoAuth, param_id("noredirect"), no_param_secret(), in_storage,     "",     NONE    ,   	proceed_not_expected, E_INVALID_CLIENT},
 	
-	{22,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params,  proceed_not_expected, E_INVALID_REQUEST},
-	{23,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	   E_INVALID_REQUEST},
-	{230,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	proceed_expected, 	   NO_ERROR},
-	{24,headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",       CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{25,headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{26,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
-	{27,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "", 	  CLIENT_SECRET_BASIC,  allow_params, 	    proceed_not_expected, 	   E_INVALID_REQUEST},
-	{28,headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "", 	  CLIENT_SECRET_BASIC,  allow_params, 	    proceed_not_expected, 	   E_INVALID_REQUEST},
-	{29,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{30,headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",       CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{31,headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",       CLIENT_SECRET_BASIC,  allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
+	{22,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,    proceed_not_expected, E_INVALID_CLIENT},
+	{23,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, 	   E_INVALID_CLIENT},
+	{230,headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,   	proceed_expected, 	   NO_ERROR},
+	{24,headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",       CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT},
+	{25,headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT},
+	{26,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret", CLIENT_SECRET_BASIC,   	    proceed_not_expected, E_INVALID_CLIENT},
+	{27,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "", 	  CLIENT_SECRET_BASIC,   	    proceed_not_expected, 	   E_INVALID_CLIENT},
+	{28,headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "", 	  CLIENT_SECRET_BASIC,   	    proceed_not_expected, 	   E_INVALID_CLIENT},
+	{29,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT},
+	{30,headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",       CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT},
+	{31,headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",       CLIENT_SECRET_BASIC,   	    proceed_not_expected, E_INVALID_CLIENT},
 	
-	{32,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        NONE	   , disallow_params, 	proceed_expected, 	   NO_ERROR},
-	{33,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        NONE	   , allow_params,     proceed_expected, 	   NO_ERROR},
-	{34,headerBadAuth, param_id("123"), no_param_secret(),      not_in_storage, "",        NONE	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{35,headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",        NONE	   , allow_params,     proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{36,headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret",  NONE	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{37,headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",        NONE	   , allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
-	{38,headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",        NONE	   , allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
-	{39,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "",        NONE	   , allow_params, 	    proceed_expected, 	   NO_ERROR},
-	{40,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret",  NONE	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{41,headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "secret",  NONE	   , allow_params,     proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{32,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        NONE	   ,  	proceed_expected, 	   NO_ERROR},
+	{33,headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        NONE	   ,      proceed_expected, 	   NO_ERROR},
+	{34,headerBadAuth, param_id("123"), no_param_secret(),      not_in_storage, "",        NONE	   ,  	    proceed_not_expected, E_INVALID_CLIENT},
+	{35,headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",        NONE	   ,      proceed_not_expected, E_INVALID_CLIENT},
+	{36,headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret",  NONE	   ,  	    proceed_not_expected, E_INVALID_CLIENT},
+	{37,headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",        NONE	   ,  	    proceed_not_expected, E_INVALID_CLIENT},
+	{38,headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",        NONE	   ,  	    proceed_not_expected, E_INVALID_CLIENT},
+	{39,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "",        NONE	   ,  	    proceed_expected, 	   NO_ERROR},
+	{40,headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret",  NONE	   ,  	    proceed_not_expected, E_INVALID_CLIENT},
+	{41,headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "secret",  NONE	   ,      proceed_not_expected, E_INVALID_CLIENT},
 	
 	
-	{42,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params,  proceed_expected,     NO_ERROR},
-	{43,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_expected,     NO_ERROR},
-	{430,headerOKAuth("", ""),         param_id("123"), param_secret("secret"),in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	  proceed_not_expected,     E_INVALID_REQUEST},
-	{44,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{45,headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 	 "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{46,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 	 "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{47,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage,     "", 	   CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, 	 E_INVALID_REQUEST},
-	{48,headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{49,headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{42,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,    proceed_expected,     NO_ERROR},
+	{43,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,   	  proceed_expected,     NO_ERROR},
+	{430,headerOKAuth("", ""),         param_id("123"), param_secret("secret"),in_storage,     "secret", CLIENT_SECRET_POST,   	  proceed_not_expected,     E_INVALID_CLIENT},
+	{44,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{45,headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 	 "secret", CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{46,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 	 "secret", CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{47,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage,     "", 	   CLIENT_SECRET_BASIC,   	  proceed_not_expected, 	 E_INVALID_CLIENT},
+	{48,headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
+	{49,headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage, "", 	   CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT},
 	
-	{50,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", NONE,  		disallow_params, proceed_expected, 	 NO_ERROR},
-	{51,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", NONE,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{52,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage,   "", 	      NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{53,headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{54,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{55,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"", 	  NONE,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{56,headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{57,headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{58,headerOKAuth("noredirect", "secret"), no_param_id(), no_param_secret(), in_storage, "secret",NONE,       allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{50,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", NONE,  		 proceed_expected, 	 NO_ERROR},
+	{51,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", NONE,  		 	  proceed_expected, 	 NO_ERROR},
+	{52,headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage,   "", 	      NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT},
+	{53,headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT},
+	{54,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT},
+	{55,headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"", 	  NONE,  		 	  proceed_expected, 	 NO_ERROR},
+	{56,headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT},
+	{57,headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT},
+	{58,headerOKAuth("noredirect", "secret"), no_param_id(), no_param_secret(), in_storage, "secret",NONE,        	  proceed_not_expected, E_INVALID_CLIENT},
 
 	}
 
@@ -160,7 +157,7 @@ func TestAuthenticateClient_other_grant_types(t *testing.T) {
 		
 		r := makeRequest(header, params)
 		r.ParseForm()
-		result := authenticateClient(storage, r, tt.allowQueryParams, "client_credentials")
+		result := authenticateClient(storage, r, "client_credentials")
 		if tt.canProceed != result.CanProceed {
 			t.Errorf("Can proceed is wrong %v", tt)
 		} else {

--- a/clientauthenticate_client_credentials_grant_type_test.go
+++ b/clientauthenticate_client_credentials_grant_type_test.go
@@ -1,0 +1,180 @@
+package osin
+
+import (
+	
+	"testing"
+	"net/url"
+	"net/http"
+	"encoding/base64"
+	"fmt"
+)
+
+func TestAuthenticateClient_other_grant_types(t *testing.T) {
+
+	headerNoAuth := &AuthHeader{}
+	headerBadAuth := &AuthHeader{ HeaderName: "Authorization", FormattedValue: "Digest XHHHHHHH"}
+	headerOKAuth :=func(username string, password string) *AuthHeader {
+		header :=  &AuthHeader{}
+		header.HeaderName = "Authorization"
+		header.FormattedValue = "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s",
+			username, password)))
+		header.UserName = &username
+		header.Password = &password
+		return header
+	}
+	
+	no_param_secret := func() *string {	return nil}
+	no_param_id := func() *string {	return nil}
+	NO_ERROR := ""
+	param_secret := func(value string) *string {return &value}
+	param_id := func(value string) *string {return &value}
+	in_storage := true;
+	not_in_storage := false;
+	allow_params := true;
+	disallow_params := false;
+	proceed_expected := true;
+	proceed_not_expected := false;
+
+	var tests = []struct {
+		header           		*AuthHeader
+		param_client_id	     	*string
+		param_client_secret    	*string
+		clientIsInStorage		bool
+		storedClientSecret		string
+		storedClientType		ClientType
+		allowQueryParams 		bool
+		canProceed       		bool
+		returnedError			string
+		
+	}{
+	{headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected,     NO_ERROR},
+	{headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 	     CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, param_id("123"), param_secret(""),	      in_storage,     "", 		 CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected,     NO_ERROR},
+	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected,     NO_ERROR},
+	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	     CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, 	  E_UNAUTHORIZED_CLIENT},
+	
+	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 PUBLIC_CLIENT	   ,  disallow_params, proceed_expected, 	   NO_ERROR},
+	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "", 		 PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	   NO_ERROR},
+	{headerNoAuth, param_id("123"), no_param_secret(),      not_in_storage, "", 		 PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, param_id("123"), param_secret("secret"), not_in_storage, "", 		 PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	     PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, no_param_id()  , no_param_secret(),      not_in_storage, "", 	     PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "", 		 PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	   NO_ERROR},
+	{headerNoAuth, param_id("123"), param_secret(""),       in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, param_id("noredirect"), no_param_secret(), in_storage,     "",     PUBLIC_CLIENT    ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	
+	{headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params,  proceed_not_expected, E_INVALID_REQUEST},
+	{headerBadAuth, param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	   NO_ERROR},
+	{headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",       CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "", 	  CONFIDENTIAL_CLIENT,  allow_params, 	    proceed_expected, 	   NO_ERROR},
+	{headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "", 	  CONFIDENTIAL_CLIENT,  allow_params, 	    proceed_expected, 	   NO_ERROR},
+	{headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",       CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",       CONFIDENTIAL_CLIENT,  allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
+	
+	{headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        PUBLIC_CLIENT	   , disallow_params, 	proceed_expected, 	   NO_ERROR},
+	{headerBadAuth, param_id("123"), no_param_secret(),      in_storage,     "",        PUBLIC_CLIENT	   , allow_params,     proceed_expected, 	   NO_ERROR},
+	{headerBadAuth, param_id("123"), no_param_secret(),      not_in_storage, "",        PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, param_id("123"), param_secret("secret"), not_in_storage, "",        PUBLIC_CLIENT	   , allow_params,     proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, param_id("123"), param_secret("xxxxxx"), in_storage,     "secret",  PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, no_param_id()  , param_secret("xxxxxx"), not_in_storage, "",        PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
+	{headerBadAuth, no_param_id()  , no_param_secret(), 	   not_in_storage, "",        PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_INVALID_REQUEST},
+	{headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "",        PUBLIC_CLIENT	   , allow_params, 	    proceed_expected, 	   NO_ERROR},
+	{headerBadAuth, param_id("123"), param_secret(""), 	   in_storage,     "secret",  PUBLIC_CLIENT	   , allow_params, 	    proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, param_id("123"), no_param_secret(), 	   in_storage,     "secret",  PUBLIC_CLIENT	   , allow_params,     proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	
+	
+	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params,  proceed_expected,     NO_ERROR},
+	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected,     NO_ERROR},
+	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage, "", 	   CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 	 "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 	 "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage,     "", 	   CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage, "", 	   CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage, "", 	   CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	
+	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", PUBLIC_CLIENT,  		disallow_params, proceed_expected, 	 NO_ERROR},
+	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), in_storage,       "secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{headerOKAuth("456", "secret"), no_param_id(), no_param_secret(), not_in_storage,   "", 	      PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", "xxxxxx"), no_param_id(), no_param_secret(), in_storage, 		"secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", ""),       no_param_id(), no_param_secret(), in_storage, 		"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{headerOKAuth("", "xxxxxx"),    no_param_id(), no_param_secret(), not_in_storage,	"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{headerOKAuth("", ""),    		 no_param_id(), no_param_secret(), not_in_storage,	"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{headerOKAuth("noredirect", "secret"), no_param_id(), no_param_secret(), in_storage, "secret",PUBLIC_CLIENT,       allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+
+	}
+
+	for _, tt := range tests {
+		
+		var client_id *string
+		
+		if tt.header.UserName != nil {
+			client_id = tt.header.UserName
+		} else {
+			client_id = tt.param_client_id
+		}
+		
+		storage := &TestingStorage{
+			clients:   make(map[string]Client),
+			authorize: make(map[string]*AuthorizeData),
+			access:    make(map[string]*AccessData),
+			refresh:   make(map[string]string),
+		}
+		
+		redirectUri := "http://localhost:14000/appauth"
+		if client_id != nil {
+		 if *client_id == "noredirect" { redirectUri = ""}
+		} 
+		if tt.clientIsInStorage && client_id != nil {
+			storage.clients[*client_id] = &DefaultClient{
+				Id:          *client_id,
+				Secret:      tt.storedClientSecret,
+				RedirectUri: redirectUri,
+				Type: tt.storedClientType,
+			}
+		}
+		
+		params := url.Values{}
+    	params.Set("grant_type", "client_credentials")
+		if tt.param_client_id != nil { params.Set("client_id", *(tt.param_client_id)) }
+		if tt.param_client_secret != nil { params.Set("client_secret", *(tt.param_client_secret)) }
+		
+		header := make(http.Header)
+		header.Set(tt.header.HeaderName, tt.header.FormattedValue)
+		
+		
+		r := makeRequest(header, params)
+		r.ParseForm()
+		result := authenticateClient(storage, r, tt.allowQueryParams, "client_credentials")
+		if tt.canProceed != result.CanProceed {
+			t.Errorf("Can proceed is wrong %v", tt)
+		} else {
+		
+			if tt.canProceed == true {
+				if result.InternalError != nil {
+					t.Errorf("Expected internalError to be nil %v", tt)
+				}
+				if result.Client.GetId() != *client_id {
+					t.Errorf("Expected ClientId to be match %v", tt)
+				}
+			}
+		}
+		
+		if tt.returnedError != result.Error {
+			t.Errorf("Expected error '%v' but was '%v'", tt.returnedError, result.Error)
+		}
+	}
+
+}
+

--- a/clientauthenticate_password_grant_type_test.go
+++ b/clientauthenticate_password_grant_type_test.go
@@ -40,10 +40,10 @@ func TestAuthenticateClient_password(t *testing.T) {
 	param_id := func(value string) *string {return &value}
 	in_storage := true;
 	not_in_storage := false;
-	allow_params := true;
-	disallow_params := false;
 	proceed_expected := true;
 	proceed_not_expected := false;
+	with_www_auth := true;
+	no_www_auth := false;
 
 	var tests = []struct {
 		id                      int
@@ -54,78 +54,78 @@ func TestAuthenticateClient_password(t *testing.T) {
 		clientIsInStorage		bool
 		storedClientSecret		string
 		storedAuthMethod		AuthMethod
-		allowQueryParams 		bool
 		canProceed       		bool
 		returnedError			string
+		must_return_www_auth    bool
 		
 	}{
-	{1, headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
-	{2, headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
-	{231,headerNoAuth,"password",  param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	proceed_expected, 	   NO_ERROR},
-	{3, headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, ""		, CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{4, headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{5, headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,   "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{6, headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     ""		, CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
-	{7, headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "", 		  CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
-	{8, headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{9, headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	      CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{10,headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	      CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{11,headerNoAuth, "password", param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
+	{1, headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{2, headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, 	  E_INVALID_CLIENT, no_www_auth},
+	{231,headerNoAuth,"password",  param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,   	proceed_expected, 	   NO_ERROR, no_www_auth},
+	{3, headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, ""		, CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{4, headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{5, headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,   "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{6, headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     ""		, CLIENT_SECRET_BASIC,   	proceed_not_expected, 	  E_INVALID_CLIENT, no_www_auth},
+	{7, headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "", 		  CLIENT_SECRET_BASIC,   	proceed_not_expected, 	  E_INVALID_CLIENT, no_www_auth},
+	{8, headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{9, headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	      CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{10,headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	      CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{11,headerNoAuth, "password", param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, 	  E_INVALID_CLIENT, no_www_auth},
 	
-	{12,headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  disallow_params, proceed_expected, 	  NO_ERROR},
-	{13,headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{14,headerNoAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{15,headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{16,headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,    "secret",NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{17,headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{18,headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	    NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{19,headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     "", 	NONE	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{20,headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,  "secret",NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{21,headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{22,headerNoAuth, "password", param_id("noredirect"), no_param_secret(), in_storage,     "",   NONE      ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{12,headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  proceed_expected, 	  NO_ERROR, no_www_auth},
+	{13,headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,   	proceed_expected, 	  NO_ERROR, no_www_auth},
+	{14,headerNoAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{15,headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{16,headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,    "secret",NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{17,headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{18,headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	    NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{19,headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     "", 	NONE	   ,   	proceed_expected, 	  NO_ERROR, no_www_auth},
+	{20,headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,  "secret",NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{21,headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "secret", NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
+	{22,headerNoAuth, "password", param_id("noredirect"), no_param_secret(), in_storage,     "",   NONE      ,   	proceed_not_expected, E_INVALID_CLIENT, no_www_auth},
 	
-	{23,headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
-	{24,headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
-	{25,headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 	    CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{26,headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{27,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{28,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
-	{29,headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "", 		CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
-	{30,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{31,headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{32,headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{23,headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{24,headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, 	  E_INVALID_CLIENT, with_www_auth},
+	{25,headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 	    CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{26,headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{27,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{28,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		CLIENT_SECRET_BASIC,   	proceed_not_expected, 	  E_INVALID_CLIENT, with_www_auth},
+	{29,headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "", 		CLIENT_SECRET_BASIC,   	proceed_not_expected, 	  E_INVALID_CLIENT, with_www_auth},
+	{30,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{31,headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{32,headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    CLIENT_SECRET_BASIC,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
 	
-	{33,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  disallow_params, proceed_expected, 	  NO_ERROR},
-	{34,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{35,headerBadAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{36,headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{37,headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{38,headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{39,headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{40,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		NONE	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{41,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", 	NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{42,headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "secret", 	NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{33,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  proceed_expected, 	  NO_ERROR, no_www_auth},
+	{34,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,   	proceed_expected, 	  NO_ERROR, no_www_auth},
+	{35,headerBadAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{36,headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{37,headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{38,headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{39,headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{40,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		NONE	   ,   	proceed_expected, 	  NO_ERROR, no_www_auth},
+	{41,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", 	NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{42,headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "secret", 	NONE	   ,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
 	
 	
-	{43,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params, proceed_expected, 	 NO_ERROR},
-	{44,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{440,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	  proceed_not_expected, 	 E_INVALID_REQUEST},
-	{45,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{46,headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{47,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{48,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, 	E_INVALID_REQUEST},
-	{49,headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{50,headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{43,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,   proceed_expected, 	 NO_ERROR, no_www_auth},
+	{44,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,   	  proceed_expected, 	 NO_ERROR, no_www_auth},
+	{440,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_POST,   	  proceed_not_expected, 	 E_INVALID_CLIENT, with_www_auth},
+	{45,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{46,headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{47,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{48,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  CLIENT_SECRET_BASIC,   	  proceed_not_expected, 	E_INVALID_CLIENT, with_www_auth},
+	{49,headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{50,headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CLIENT_SECRET_BASIC,   	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
 	
-	{51,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", NONE,  		disallow_params, proceed_expected, 	 NO_ERROR},
-	{52,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", NONE,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{53,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{54,headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{55,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{56,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  NONE,  		allow_params, 	  proceed_expected, 	NO_ERROR},
-	{57,headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{58,headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{59,headerOKAuth("noredirect", "secret"), "password", no_param_id(), no_param_secret(), in_storage, "secret",     NONE      ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{51,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", NONE,  		 proceed_expected, 	 NO_ERROR, no_www_auth},
+	{52,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", NONE,  		 	  proceed_expected, 	 NO_ERROR, no_www_auth},
+	{53,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{54,headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{55,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{56,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  NONE,  		 	  proceed_expected, 	NO_ERROR, no_www_auth},
+	{57,headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{58,headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		 	  proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
+	{59,headerOKAuth("noredirect", "secret"), "password", no_param_id(), no_param_secret(), in_storage, "secret",     NONE      ,   	proceed_not_expected, E_INVALID_CLIENT, with_www_auth},
 
 	}
 
@@ -170,7 +170,7 @@ func TestAuthenticateClient_password(t *testing.T) {
 		
 		r := makeRequest(header, params)
 		r.ParseForm()
-		result := authenticateClient(storage, r, tt.allowQueryParams, tt.grant_type)
+		result := authenticateClient(storage, r, tt.grant_type)
 		if tt.canProceed != result.CanProceed {
 			t.Errorf("Can proceed is wrong %v", tt)
 		} else {
@@ -188,6 +188,11 @@ func TestAuthenticateClient_password(t *testing.T) {
 		if tt.returnedError != result.Error {
 			t.Errorf("Expected error '%v' but was '%v',  %v", tt.returnedError, result.Error, tt)
 		}
+		
+		if tt.must_return_www_auth != result.MustReturn401 {
+			t.Errorf("Expected www-authenticate to be '%v' but was '%v',  %v", tt.must_return_www_auth, result.MustReturn401, tt)
+		}
+				
 	}
 
 }

--- a/clientauthenticate_password_grant_type_test.go
+++ b/clientauthenticate_password_grant_type_test.go
@@ -46,83 +46,86 @@ func TestAuthenticateClient_password(t *testing.T) {
 	proceed_not_expected := false;
 
 	var tests = []struct {
+		id                      int
 		header           		*AuthHeader
 		grant_type       		string
 		param_client_id	     	*string
 		param_client_secret    	*string
 		clientIsInStorage		bool
 		storedClientSecret		string
-		storedClientType		ClientType
+		storedAuthMethod		AuthMethod
 		allowQueryParams 		bool
 		canProceed       		bool
 		returnedError			string
 		
 	}{
-	{headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, ""		, CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,   "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     ""		, CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "", 		  CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	      CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	      CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, "password", param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, 	  E_UNAUTHORIZED_CLIENT},
+	{1, headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
+	{2, headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
+	{231,headerNoAuth,"password",  param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	proceed_expected, 	   NO_ERROR},
+	{3, headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, ""		, CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{4, headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{5, headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,   "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{6, headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     ""		, CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
+	{7, headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "", 		  CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
+	{8, headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{9, headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	      CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{10,headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	      CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{11,headerNoAuth, "password", param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
 	
-	{headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		PUBLIC_CLIENT	   ,  disallow_params, proceed_expected, 	  NO_ERROR},
-	{headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerNoAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,    "secret",PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	    PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     "", 	PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,  "secret",PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerNoAuth, "password", param_id("noredirect"), no_param_secret(), in_storage,     "",   PUBLIC_CLIENT      ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{12,headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  disallow_params, proceed_expected, 	  NO_ERROR},
+	{13,headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{14,headerNoAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{15,headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{16,headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,    "secret",NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{17,headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{18,headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	    NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{19,headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     "", 	NONE	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{20,headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,  "secret",NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{21,headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{22,headerNoAuth, "password", param_id("noredirect"), no_param_secret(), in_storage,     "",   NONE      ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
 	
-	{headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
-	{headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 	    CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "", 		CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{23,headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
+	{24,headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
+	{25,headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 	    CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{26,headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{27,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{28,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
+	{29,headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "", 		CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, 	  E_INVALID_REQUEST},
+	{30,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{31,headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{32,headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    CLIENT_SECRET_BASIC,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
 	
-	{headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		PUBLIC_CLIENT	   ,  disallow_params, proceed_expected, 	  NO_ERROR},
-	{headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerBadAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
-	{headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
-	{headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", 	PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "secret", 	PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{33,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  disallow_params, proceed_expected, 	  NO_ERROR},
+	{34,headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		NONE	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{35,headerBadAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{36,headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{37,headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{38,headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{39,headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    NONE	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{40,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		NONE	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{41,headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", 	NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{42,headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "secret", 	NONE	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
 	
 	
-	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params, proceed_expected, 	 NO_ERROR},
-	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected, 	NO_ERROR},
-	{headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{43,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,  disallow_params, proceed_expected, 	 NO_ERROR},
+	{44,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{440,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CLIENT_SECRET_POST,  allow_params, 	  proceed_not_expected, 	 E_INVALID_REQUEST},
+	{45,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{46,headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{47,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{48,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, 	E_INVALID_REQUEST},
+	{49,headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{50,headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CLIENT_SECRET_BASIC,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
 	
-	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", PUBLIC_CLIENT,  		disallow_params, proceed_expected, 	 NO_ERROR},
-	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
-	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
-	{headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_expected, 	NO_ERROR},
-	{headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
-	{headerOKAuth("noredirect", "secret"), "password", no_param_id(), no_param_secret(), in_storage, "secret",     PUBLIC_CLIENT      ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{51,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", NONE,  		disallow_params, proceed_expected, 	 NO_ERROR},
+	{52,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", NONE,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{53,headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{54,headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{55,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", NONE,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{56,headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  NONE,  		allow_params, 	  proceed_expected, 	NO_ERROR},
+	{57,headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{58,headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  NONE,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{59,headerOKAuth("noredirect", "secret"), "password", no_param_id(), no_param_secret(), in_storage, "secret",     NONE      ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
 
 	}
 
@@ -152,7 +155,7 @@ func TestAuthenticateClient_password(t *testing.T) {
 				Id:          *client_id,
 				Secret:      tt.storedClientSecret,
 				RedirectUri: redirectUri,
-				Type: tt.storedClientType,
+				AuthMethod: tt.storedAuthMethod,
 			}
 		}
 		
@@ -183,7 +186,7 @@ func TestAuthenticateClient_password(t *testing.T) {
 		}
 		
 		if tt.returnedError != result.Error {
-			t.Errorf("Expected error '%v' but was '%v'", tt.returnedError, result.Error)
+			t.Errorf("Expected error '%v' but was '%v',  %v", tt.returnedError, result.Error, tt)
 		}
 	}
 

--- a/clientauthenticate_password_grant_type_test.go
+++ b/clientauthenticate_password_grant_type_test.go
@@ -1,0 +1,198 @@
+package osin
+
+import (
+	
+	"testing"
+	"net/url"
+	"net/http"
+	"bytes"
+	"strconv"
+	"encoding/base64"
+	"fmt"
+)
+
+type AuthHeader struct {
+	UserName		*string
+	Password		*string
+	HeaderName 		string
+	FormattedValue 	string
+}
+
+
+func TestAuthenticateClient_password(t *testing.T) {
+
+	headerNoAuth := &AuthHeader{}
+	headerBadAuth := &AuthHeader{ HeaderName: "Authorization", FormattedValue: "Digest XHHHHHHH"}
+	headerOKAuth :=func(username string, password string) *AuthHeader {
+		header :=  &AuthHeader{}
+		header.HeaderName = "Authorization"
+		header.FormattedValue = "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s",
+			username, password)))
+		header.UserName = &username
+		header.Password = &password
+		return header
+	}
+	
+	no_param_secret := func() *string {	return nil}
+	no_param_id := func() *string {	return nil}
+	NO_ERROR := ""
+	param_secret := func(value string) *string {return &value}
+	param_id := func(value string) *string {return &value}
+	in_storage := true;
+	not_in_storage := false;
+	allow_params := true;
+	disallow_params := false;
+	proceed_expected := true;
+	proceed_not_expected := false;
+
+	var tests = []struct {
+		header           		*AuthHeader
+		grant_type       		string
+		param_client_id	     	*string
+		param_client_secret    	*string
+		clientIsInStorage		bool
+		storedClientSecret		string
+		storedClientType		ClientType
+		allowQueryParams 		bool
+		canProceed       		bool
+		returnedError			string
+		
+	}{
+	{headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, ""		, CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,   "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     ""		, CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "", 		  CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	      CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	      CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, "password", param_id("noredirect"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, 	  E_UNAUTHORIZED_CLIENT},
+	
+	{headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		PUBLIC_CLIENT	   ,  disallow_params, proceed_expected, 	  NO_ERROR},
+	{headerNoAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerNoAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,    "secret",PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, "password", no_param_id()  , no_param_secret(), 	 not_in_storage, "", 	    PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,     "", 	PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerNoAuth, "password", param_id("123"), param_secret(""), 		 in_storage,  "secret",PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", param_id("123"), no_param_secret(), 	 in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerNoAuth, "password", param_id("noredirect"), no_param_secret(), in_storage,     "",   PUBLIC_CLIENT      ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	
+	{headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params, proceed_not_expected, E_INVALID_REQUEST},
+	{headerBadAuth, "password", param_id("123"), param_secret("secret"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 	    CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "", 		CONFIDENTIAL_CLIENT,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    CONFIDENTIAL_CLIENT,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	
+	{headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		PUBLIC_CLIENT	   ,  disallow_params, proceed_expected, 	  NO_ERROR},
+	{headerBadAuth, "password", param_id("123"), no_param_secret(),      in_storage,     "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerBadAuth, "password", param_id("123"), no_param_secret(),      not_in_storage, "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, "password", param_id("123"), param_secret("secret"), not_in_storage, "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, "password", param_id("123"), param_secret("xxxxxx"), in_storage,     "secret", PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, "password", no_param_id()  , param_secret("xxxxxx"), not_in_storage, "", 	    PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerBadAuth, "password", no_param_id()  , no_param_secret(), 	  not_in_storage, "", 	    PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_INVALID_REQUEST},
+	{headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "", 		PUBLIC_CLIENT	   ,  allow_params, 	proceed_expected, 	  NO_ERROR},
+	{headerBadAuth, "password", param_id("123"), param_secret(""), 	  in_storage,     "secret", 	PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerBadAuth, "password", param_id("123"), no_param_secret(), 	  in_storage,     "secret", 	PUBLIC_CLIENT	   ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	
+	
+	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CONFIDENTIAL_CLIENT,  disallow_params, proceed_expected, 	 NO_ERROR},
+	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_expected, 	NO_ERROR},
+	{headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  CONFIDENTIAL_CLIENT,  allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	
+	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", PUBLIC_CLIENT,  		disallow_params, proceed_expected, 	 NO_ERROR},
+	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), in_storage,     "secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_expected, 	 NO_ERROR},
+	{headerOKAuth("456", "secret"), "password", no_param_id(), no_param_secret(), not_in_storage, "", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", "xxxxxx"), "password", no_param_id(), no_param_secret(), in_storage, 		"secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"secret", PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+	{headerOKAuth("456", ""),       "password", no_param_id(), no_param_secret(), in_storage, 		"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_expected, 	NO_ERROR},
+	{headerOKAuth("", "xxxxxx"),    "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{headerOKAuth("", ""),    		 "password", no_param_id(), no_param_secret(), not_in_storage,	"", 	  PUBLIC_CLIENT,  		allow_params, 	  proceed_not_expected, E_INVALID_REQUEST},
+	{headerOKAuth("noredirect", "secret"), "password", no_param_id(), no_param_secret(), in_storage, "secret",     PUBLIC_CLIENT      ,  allow_params, 	proceed_not_expected, E_UNAUTHORIZED_CLIENT},
+
+	}
+
+	for _, tt := range tests {
+		
+		var client_id *string
+		
+		if tt.header.UserName != nil {
+			client_id = tt.header.UserName
+		} else {
+			client_id = tt.param_client_id
+		}
+		
+		storage := &TestingStorage{
+			clients:   make(map[string]Client),
+			authorize: make(map[string]*AuthorizeData),
+			access:    make(map[string]*AccessData),
+			refresh:   make(map[string]string),
+		}
+		
+		redirectUri := "http://localhost:14000/appauth"
+		if client_id != nil {
+		 if *client_id == "noredirect" { redirectUri = ""}
+		} 
+		if tt.clientIsInStorage && client_id != nil {
+			storage.clients[*client_id] = &DefaultClient{
+				Id:          *client_id,
+				Secret:      tt.storedClientSecret,
+				RedirectUri: redirectUri,
+				Type: tt.storedClientType,
+			}
+		}
+		
+		params := url.Values{}
+    	params.Set("grant_type", tt.grant_type)
+		if tt.param_client_id != nil { params.Set("client_id", *(tt.param_client_id)) }
+		if tt.param_client_secret != nil { params.Set("client_secret", *(tt.param_client_secret)) }
+		
+		header := make(http.Header)
+		header.Set(tt.header.HeaderName, tt.header.FormattedValue)
+		
+		
+		r := makeRequest(header, params)
+		r.ParseForm()
+		result := authenticateClient(storage, r, tt.allowQueryParams, tt.grant_type)
+		if tt.canProceed != result.CanProceed {
+			t.Errorf("Can proceed is wrong %v", tt)
+		} else {
+		
+			if tt.canProceed == true {
+				if result.InternalError != nil {
+					t.Errorf("Expected internalError to be nil %v", tt)
+				}
+				if result.Client.GetId() != *client_id {
+					t.Errorf("Expected ClientId to be match %v", tt)
+				}
+			}
+		}
+		
+		if tt.returnedError != result.Error {
+			t.Errorf("Expected error '%v' but was '%v'", tt.returnedError, result.Error)
+		}
+	}
+
+}
+
+func makeRequest(header http.Header, params url.Values) *http.Request {
+	r, _ := http.NewRequest("POST", "/token", bytes.NewBufferString(params.Encode()))
+    r.Header = header
+    r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+    r.Header.Add("Content-Length", strconv.Itoa(len(params.Encode())))
+	return r
+}

--- a/config.go
+++ b/config.go
@@ -30,8 +30,8 @@ func (t AllowedAccessType) Exists(rt AccessRequestType) bool {
 type ServerConfig struct {
 	// Authorization token expiration in seconds (default 5 minutes)
 	AuthorizationExpiration int32
-
-	// Access token expiration in seconds (default 1 hour)
+	
+		// Access token expiration in seconds (default 1 hour)
 	AccessExpiration int32
 
 	// Token type to return
@@ -57,6 +57,9 @@ type ServerConfig struct {
 	// Separator to support multiple URIs in Client.GetRedirectUri().
 	// If blank (the default), don't allow multiple URIs.
 	RedirectUriSeparator string
+	
+	// A realm which is issued with the authentication scheme challenge
+	BasicAuthRealm string
 }
 
 // NewServerConfig returns a new ServerConfig with default configuration
@@ -70,5 +73,6 @@ func NewServerConfig() *ServerConfig {
 		ErrorStatusCode:           200,
 		AllowClientSecretInParams: false,
 		AllowGetAccessRequest:     false,
+		BasicAuthRealm :           "",
 	}
 }

--- a/example/osincliclient/osincliclient.go
+++ b/example/osincliclient/osincliclient.go
@@ -24,6 +24,7 @@ func main() {
 		Id:          "1234",
 		Secret:      "aabbccdd",
 		RedirectUri: "http://localhost:14001/appauth",
+		Type: CONFIDENTIAL_CLIENT,
 	})
 	server := osin.NewServer(config, sstorage)
 

--- a/example/osincliclient/osincliclient.go
+++ b/example/osincliclient/osincliclient.go
@@ -24,7 +24,7 @@ func main() {
 		Id:          "1234",
 		Secret:      "aabbccdd",
 		RedirectUri: "http://localhost:14001/appauth",
-		Type: CONFIDENTIAL_CLIENT,
+		AuthMethod: CLIENT_SECRET_BASIC,
 	})
 	server := osin.NewServer(config, sstorage)
 

--- a/example/teststorage.go
+++ b/example/teststorage.go
@@ -25,6 +25,14 @@ func NewTestStorage() *TestStorage {
 		Id:          "1234",
 		Secret:      "aabbccdd",
 		RedirectUri: "http://localhost:14000/appauth",
+		Type: CONFIDENTIAL_CLIENT,
+	}
+	
+	r.clients["4567"] = &DefaultClient{
+		Id:          "4567",
+		Secret:      "",
+		RedirectUri: "http://localhost:14000/appauth",
+		Type: PUBLIC_CLIENT,
 	}
 
 	return r

--- a/example/teststorage.go
+++ b/example/teststorage.go
@@ -25,14 +25,14 @@ func NewTestStorage() *TestStorage {
 		Id:          "1234",
 		Secret:      "aabbccdd",
 		RedirectUri: "http://localhost:14000/appauth",
-		Type: CONFIDENTIAL_CLIENT,
+		AuthMethod: CLIENT_SECRET_BASIC,
 	}
 	
 	r.clients["4567"] = &DefaultClient{
 		Id:          "4567",
 		Secret:      "",
 		RedirectUri: "http://localhost:14000/appauth",
-		Type: PUBLIC_CLIENT,
+		AuthMethod: NONE,
 	}
 
 	return r

--- a/storage_test.go
+++ b/storage_test.go
@@ -25,6 +25,14 @@ func NewTestingStorage() *TestingStorage {
 		Id:          "1234",
 		Secret:      "aabbccdd",
 		RedirectUri: "http://localhost:14000/appauth",
+		Type: CONFIDENTIAL_CLIENT,
+	}
+	
+	r.clients["4567"] = &DefaultClient{
+		Id:          "4567",
+		Secret:      "",
+		RedirectUri: "http://localhost:14000/appauth",
+		Type: PUBLIC_CLIENT,
 	}
 
 	r.authorize["9999"] = &AuthorizeData{
@@ -69,7 +77,7 @@ func (s *TestingStorage) GetClient(id string) (Client, error) {
 	if c, ok := s.clients[id]; ok {
 		return c, nil
 	}
-	return nil, errors.New("Client not found")
+	return nil,nil
 }
 
 func (s *TestingStorage) SetClient(id string, client Client) error {

--- a/storage_test.go
+++ b/storage_test.go
@@ -25,14 +25,14 @@ func NewTestingStorage() *TestingStorage {
 		Id:          "1234",
 		Secret:      "aabbccdd",
 		RedirectUri: "http://localhost:14000/appauth",
-		Type: CONFIDENTIAL_CLIENT,
+		AuthMethod: CLIENT_SECRET_BASIC,
 	}
 	
 	r.clients["4567"] = &DefaultClient{
 		Id:          "4567",
 		Secret:      "",
 		RedirectUri: "http://localhost:14000/appauth",
-		Type: PUBLIC_CLIENT,
+		AuthMethod: NONE,
 	}
 
 	r.authorize["9999"] = &AuthorizeData{

--- a/util.go
+++ b/util.go
@@ -16,29 +16,30 @@ type BasicAuth struct {
 // Parse bearer authentication header
 type BearerAuth struct {
 	Code string
+	AuthorizationHeaderFound bool
 }
 
 // Return authorization header data
-func CheckBasicAuth(r *http.Request) (*BasicAuth, error) {
+func CheckBasicAuth(r *http.Request) (*BasicAuth, bool, error) {
 	if r.Header.Get("Authorization") == "" {
-		return nil, nil
+		return nil, false, nil
 	}
 
 	s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
 	if len(s) != 2 || s[0] != "Basic" {
-		return nil, errors.New("Invalid authorization header")
+		return nil, true, errors.New("Invalid authorization header")
 	}
 
 	b, err := base64.StdEncoding.DecodeString(s[1])
 	if err != nil {
-		return nil, err
+		return nil, true, err
 	}
 	pair := strings.SplitN(string(b), ":", 2)
 	if len(pair) != 2 {
-		return nil, errors.New("Invalid authorization message")
+		return nil, true, errors.New("Invalid authorization message")
 	}
 
-	return &BasicAuth{Username: pair[0], Password: pair[1]}, nil
+	return &BasicAuth{Username: pair[0], Password: pair[1]}, true, nil
 }
 
 // Return "Bearer" token from request. The header has precedence over query string.

--- a/util.go
+++ b/util.go
@@ -59,34 +59,3 @@ func CheckBearerAuth(r *http.Request) *BearerAuth {
 	return &BearerAuth{Code: token}
 }
 
-// getClientAuth checks client basic authentication in params if allowed,
-// otherwise gets it from the header.
-// Sets an error on the response if no auth is present or a server error occurs.
-func getClientAuth(w *Response, r *http.Request, allowQueryParams bool) *BasicAuth {
-
-	if allowQueryParams {
-		// Allow for auth without password
-		if _, hasSecret := r.Form["client_secret"]; hasSecret {
-			auth := &BasicAuth{
-				Username: r.Form.Get("client_id"),
-				Password: r.Form.Get("client_secret"),
-			}
-			if auth.Username != "" {
-				return auth
-			}
-		}
-	}
-
-	auth, err := CheckBasicAuth(r)
-	if err != nil {
-		w.SetError(E_INVALID_REQUEST, "")
-		w.InternalError = err
-		return nil
-	}
-	if auth == nil {
-		w.SetError(E_INVALID_REQUEST, "")
-		w.InternalError = errors.New("Client authentication not sent")
-		return nil
-	}
-	return auth
-}

--- a/util_test.go
+++ b/util_test.go
@@ -16,28 +16,28 @@ func TestBasicAuth(t *testing.T) {
 	r := &http.Request{Header: make(http.Header)}
 
 	// Without any header
-	if b, err := CheckBasicAuth(r); b != nil || err != nil {
+	if b, authHeaderFound, err := CheckBasicAuth(r); b != nil || authHeaderFound || err != nil {
 		t.Errorf("Validated basic auth without header")
 	}
 
 	// with invalid header
 	r.Header.Set("Authorization", badAuthValue)
-	b, err := CheckBasicAuth(r)
-	if b != nil || err == nil {
+	b, authHeaderFound, err := CheckBasicAuth(r)
+	if b != nil || authHeaderFound == false || err == nil {
 		t.Errorf("Validated invalid auth")
 		return
 	}
-
+	
 	// with valid header
 	r.Header.Set("Authorization", goodAuthValue)
-	b, err = CheckBasicAuth(r)
-	if b == nil || err != nil {
+	b, authHeaderFound, err = CheckBasicAuth(r)
+	if b == nil || authHeaderFound == false || err != nil {
 		t.Errorf("Could not extract basic auth")
 		return
 	}
 
 	// check extracted auth data
-	if b.Username != "test" || b.Password != "test" {
+	if b.Username != "test" || authHeaderFound == false || b.Password != "test" {
 		t.Errorf("Error decoding basic auth")
 	}
 }

--- a/util_test.go
+++ b/util_test.go
@@ -42,60 +42,6 @@ func TestBasicAuth(t *testing.T) {
 	}
 }
 
-func TestGetClientAuth(t *testing.T) {
-
-	urlWithSecret, _ := url.Parse("http://host.tld/path?client_id=xxx&client_secret=yyy")
-	urlWithEmptySecret, _ := url.Parse("http://host.tld/path?client_id=xxx&client_secret=")
-	urlNoSecret, _ := url.Parse("http://host.tld/path?client_id=xxx")
-
-	headerNoAuth := make(http.Header)
-	headerBadAuth := make(http.Header)
-	headerBadAuth.Set("Authorization", badAuthValue)
-	headerOKAuth := make(http.Header)
-	headerOKAuth.Set("Authorization", goodAuthValue)
-
-	var tests = []struct {
-		header           http.Header
-		url              *url.URL
-		allowQueryParams bool
-		expectAuth       bool
-	}{
-		{headerNoAuth, urlWithSecret, true, true},
-		{headerNoAuth, urlWithSecret, false, false},
-		{headerNoAuth, urlWithEmptySecret, true, true},
-		{headerNoAuth, urlWithEmptySecret, false, false},
-		{headerNoAuth, urlNoSecret, true, false},
-		{headerNoAuth, urlNoSecret, false, false},
-
-		{headerBadAuth, urlWithSecret, true, true},
-		{headerBadAuth, urlWithSecret, false, false},
-		{headerBadAuth, urlWithEmptySecret, true, true},
-		{headerBadAuth, urlWithEmptySecret, false, false},
-		{headerBadAuth, urlNoSecret, true, false},
-		{headerBadAuth, urlNoSecret, false, false},
-
-		{headerOKAuth, urlWithSecret, true, true},
-		{headerOKAuth, urlWithSecret, false, true},
-		{headerOKAuth, urlWithEmptySecret, true, true},
-		{headerOKAuth, urlWithEmptySecret, false, true},
-		{headerOKAuth, urlNoSecret, true, true},
-		{headerOKAuth, urlNoSecret, false, true},
-	}
-
-	for _, tt := range tests {
-		w := new(Response)
-		r := &http.Request{Header: tt.header, URL: tt.url}
-		r.ParseForm()
-		auth := getClientAuth(w, r, tt.allowQueryParams)
-		if tt.expectAuth && auth == nil {
-			t.Errorf("Auth should not be nil for %v", tt)
-		} else if !tt.expectAuth && auth != nil {
-			t.Errorf("Auth should be nil for %v", tt)
-		}
-	}
-
-}
-
 func TestBearerAuth(t *testing.T) {
 	r := &http.Request{Header: make(http.Header)}
 


### PR DESCRIPTION
I ran into an issue with token requests for a "Public" client and not supplying the client_secret.

I've introduce a client type property that can be either public, or confidential.

The rules are in the RFC 6749, but to summarise they are.

client_credentials: MUST authenticate with the client_secret.

However Refresh_token, password, and authorization_code support "Public" clients, who can't securely keep their client_secret, so it's not necessary to send them.

Furthermore if the above public clients have any secret associated with them, or the requests supply a password then authentication with the client_secret MUST take place.
