### PR TITLE
fixed: redirect_uri is double unescaped in HandleAuthorizeRequest

### DIFF
--- a/authorize.go
+++ b/authorize.go
@@ -2,7 +2,6 @@ package osin
 
 import (
 	"net/http"
-	"net/url"
 	"time"
 )
 
@@ -89,12 +88,7 @@ func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *Authorize
 	r.ParseForm()
 
 	// create the authorization request
-	unescapedUri, err := url.QueryUnescape(r.Form.Get("redirect_uri"))
-	if err != nil {
-		w.SetErrorState(E_INVALID_REQUEST, "", "")
-		w.InternalError = err
-		return nil
-	}
+	unescapedUri := r.Form.Get("redirect_uri")
 
 	ret := &AuthorizeRequest{
 		State:       r.Form.Get("state"),
@@ -104,6 +98,7 @@ func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *Authorize
 		HttpRequest: r,
 	}
 
+	var err error
 	// must have a valid client
 	ret.Client, err = w.Storage.GetClient(r.Form.Get("client_id"))
 	if err != nil {

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -6,83 +6,119 @@ import (
 	"testing"
 )
 
+var redirectURITestCases = map[string]struct {
+	StorageURI string
+	RequestURI string
+}{
+	"unspecified": {
+		StorageURI: "http://localhost:14000/appauth",
+		RequestURI: "",
+	},
+	"specified": {
+		StorageURI: "http://localhost:14000/appauth",
+		RequestURI: "http://localhost:14000/appauth",
+	},
+	"special": {
+		StorageURI: "http://localhost:14000/app%25auth",
+		RequestURI: "http://localhost:14000/app%25auth",
+	},
+}
+
 func TestAuthorizeCode(t *testing.T) {
-	sconfig := NewServerConfig()
-	sconfig.AllowedAuthorizeTypes = AllowedAuthorizeType{CODE}
-	server := NewServer(sconfig, NewTestingStorage())
-	server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
-	resp := server.NewResponse()
+	for desc, testcase := range redirectURITestCases {
+		sconfig := NewServerConfig()
+		sconfig.AllowedAuthorizeTypes = AllowedAuthorizeType{CODE}
+		server := NewServer(sconfig, NewTestingStorageWithRedirectURI(testcase.StorageURI))
+		server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
+		resp := server.NewResponse()
 
-	req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Form = make(url.Values)
-	req.Form.Set("response_type", string(CODE))
-	req.Form.Set("client_id", "1234")
-	req.Form.Set("state", "a")
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Form = make(url.Values)
+		req.Form.Set("response_type", string(CODE))
+		req.Form.Set("client_id", "1234")
+		req.Form.Set("state", "a")
+		if len(testcase.RequestURI) > 0 {
+			req.Form.Set("redirect_uri", testcase.RequestURI)
+		}
 
-	if ar := server.HandleAuthorizeRequest(resp, req); ar != nil {
-		ar.Authorized = true
-		server.FinishAuthorizeRequest(resp, req, ar)
-	}
+		if ar := server.HandleAuthorizeRequest(resp, req); ar != nil {
+			ar.Authorized = true
+			server.FinishAuthorizeRequest(resp, req, ar)
+		}
 
-	//fmt.Printf("%+v", resp)
+		//fmt.Printf("%+v", resp)
 
-	if resp.IsError && resp.InternalError != nil {
-		t.Fatalf("Error in response: %s", resp.InternalError)
-	}
+		if resp.IsError && resp.InternalError != nil {
+			t.Errorf("%s: Error in response: %s", desc, resp.InternalError)
+			continue
+		}
 
-	if resp.IsError {
-		t.Fatalf("Should not be an error")
-	}
+		if resp.IsError {
+			t.Errorf("%s: Should not be an error", desc)
+			continue
+		}
 
-	if resp.Type != REDIRECT {
-		t.Fatalf("Response should be a redirect")
-	}
+		if resp.Type != REDIRECT {
+			t.Errorf("%s: Response should be a redirect", desc)
+			continue
+		}
 
-	if d := resp.Output["code"]; d != "1" {
-		t.Fatalf("Unexpected authorization code: %s", d)
+		if d := resp.Output["code"]; d != "1" {
+			t.Errorf("%s: Unexpected authorization code: %s", desc, d)
+			continue
+		}
 	}
 }
 
 func TestAuthorizeToken(t *testing.T) {
-	sconfig := NewServerConfig()
-	sconfig.AllowedAuthorizeTypes = AllowedAuthorizeType{TOKEN}
-	server := NewServer(sconfig, NewTestingStorage())
-	server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
-	server.AccessTokenGen = &TestingAccessTokenGen{}
-	resp := server.NewResponse()
+	for desc, testcase := range redirectURITestCases {
+		sconfig := NewServerConfig()
+		sconfig.AllowedAuthorizeTypes = AllowedAuthorizeType{TOKEN}
+		server := NewServer(sconfig, NewTestingStorageWithRedirectURI(testcase.StorageURI))
+		server.AuthorizeTokenGen = &TestingAuthorizeTokenGen{}
+		server.AccessTokenGen = &TestingAccessTokenGen{}
+		resp := server.NewResponse()
 
-	req, err := http.NewRequest("GET", "http://localhost:14000/appauth", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Form = make(url.Values)
-	req.Form.Set("response_type", string(TOKEN))
-	req.Form.Set("client_id", "1234")
-	req.Form.Set("state", "a")
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Form = make(url.Values)
+		req.Form.Set("response_type", string(TOKEN))
+		req.Form.Set("client_id", "1234")
+		req.Form.Set("state", "a")
+		if len(testcase.RequestURI) > 0 {
+			req.Form.Set("redirect_uri", testcase.RequestURI)
+		}
 
-	if ar := server.HandleAuthorizeRequest(resp, req); ar != nil {
-		ar.Authorized = true
-		server.FinishAuthorizeRequest(resp, req, ar)
-	}
+		if ar := server.HandleAuthorizeRequest(resp, req); ar != nil {
+			ar.Authorized = true
+			server.FinishAuthorizeRequest(resp, req, ar)
+		}
 
-	//fmt.Printf("%+v", resp)
+		//fmt.Printf("%+v", resp)
 
-	if resp.IsError && resp.InternalError != nil {
-		t.Fatalf("Error in response: %s", resp.InternalError)
-	}
+		if resp.IsError && resp.InternalError != nil {
+			t.Errorf("%s: Error in response: %s", desc, resp.InternalError)
+			continue
+		}
 
-	if resp.IsError {
-		t.Fatalf("Should not be an error")
-	}
+		if resp.IsError {
+			t.Errorf("%s: Should not be an error", desc)
+			continue
+		}
 
-	if resp.Type != REDIRECT || !resp.RedirectInFragment {
-		t.Fatalf("Response should be a redirect with fragment")
-	}
+		if resp.Type != REDIRECT || !resp.RedirectInFragment {
+			t.Errorf("%s: Response should be a redirect with fragment", desc)
+			continue
+		}
 
-	if d := resp.Output["access_token"]; d != "1" {
-		t.Fatalf("Unexpected access token: %s", d)
+		if d := resp.Output["access_token"]; d != "1" {
+			t.Errorf("%s: Unexpected access token: %s", desc, d)
+			continue
+		}
 	}
 }

--- a/storage_test.go
+++ b/storage_test.go
@@ -14,6 +14,10 @@ type TestingStorage struct {
 }
 
 func NewTestingStorage() *TestingStorage {
+	return NewTestingStorageWithRedirectURI("http://localhost:14000/appauth")
+}
+
+func NewTestingStorageWithRedirectURI(redirectURI string) *TestingStorage {
 	r := &TestingStorage{
 		clients:   make(map[string]Client),
 		authorize: make(map[string]*AuthorizeData),
@@ -24,7 +28,7 @@ func NewTestingStorage() *TestingStorage {
 	r.clients["1234"] = &DefaultClient{
 		Id:          "1234",
 		Secret:      "aabbccdd",
-		RedirectUri: "http://localhost:14000/appauth",
+		RedirectUri: redirectURI,
 	}
 
 	r.authorize["9999"] = &AuthorizeData{
@@ -32,7 +36,7 @@ func NewTestingStorage() *TestingStorage {
 		Code:        "9999",
 		ExpiresIn:   3600,
 		CreatedAt:   time.Now(),
-		RedirectUri: "http://localhost:14000/appauth",
+		RedirectUri: redirectURI,
 	}
 
 	r.access["9999"] = &AccessData{


### PR DESCRIPTION
Values from `r.Form.Get` have already been unescaped. Therefore `url.QueryUnescape(r.Form.Get("redirect_uri"))` would cause `redirect_uri` being unescaped twice.

For example, if  unescaped redirect URI is

```
http://localhost:8000/admin/cb?continue=%2Fadmin
```

then the authorize request will be 

```
/authorize?client_id=redeem&redirect_uri=http%3A%2F%2Flocalhost%3A8000%2Fadmin%2Fcb%3Fcontinue%3D%252Fadmin&response_type=code&scope=
```

and redirect_uri should be decoded as

```
http://localhost:8000/admin/cb?continue=%2Fadmin
```

but the original code decode it wrongly as 

```
http://localhost:8000/admin/cb?continue=/admin
```
