### PR TITLE
Add customizeable scope subsetting function.

### DIFF
--- a/access_test.go
+++ b/access_test.go
@@ -195,29 +195,6 @@ func TestAccessClientCredentials(t *testing.T) {
 	}
 }
 
-func TestExtraScopes(t *testing.T) {
-	if extraScopes("", "") == true {
-		t.Fatalf("extraScopes returned true with empty scopes")
-	}
-
-	if extraScopes("a", "") == true {
-		t.Fatalf("extraScopes returned true with less scopes")
-	}
-
-	if extraScopes("a,b", "b,a") == true {
-		t.Fatalf("extraScopes returned true with matching scopes")
-	}
-
-	if extraScopes("a,b", "b,a,c") == false {
-		t.Fatalf("extraScopes returned false with extra scopes")
-	}
-
-	if extraScopes("", "a") == false {
-		t.Fatalf("extraScopes returned false with extra scopes")
-	}
-
-}
-
 // clientWithoutMatcher just implements the base Client interface
 type clientWithoutMatcher struct {
 	Id          string

--- a/server.go
+++ b/server.go
@@ -6,21 +6,23 @@ import (
 
 // Server is an OAuth2 implementation
 type Server struct {
-	Config            *ServerConfig
-	Storage           Storage
-	AuthorizeTokenGen AuthorizeTokenGen
-	AccessTokenGen    AccessTokenGen
-	Now               func() time.Time
+	Config               *ServerConfig
+	Storage              Storage
+	AuthorizeTokenGen    AuthorizeTokenGen
+	AccessTokenGen       AccessTokenGen
+	Now                  func() time.Time
+	AccessTokenSubScoper AccessTokenSubScoper
 }
 
 // NewServer creates a new server instance
 func NewServer(config *ServerConfig, storage Storage) *Server {
 	return &Server{
-		Config:            config,
-		Storage:           storage,
-		AuthorizeTokenGen: &AuthorizeTokenGenDefault{},
-		AccessTokenGen:    &AccessTokenGenDefault{},
-		Now:               time.Now,
+		Config:               config,
+		Storage:              storage,
+		AuthorizeTokenGen:    &AuthorizeTokenGenDefault{},
+		AccessTokenGen:       &AccessTokenGenDefault{},
+		Now:                  time.Now,
+		AccessTokenSubScoper: &AccessTokenSubScoperDefault{},
 	}
 }
 

--- a/tokengen.go
+++ b/tokengen.go
@@ -2,6 +2,8 @@ package osin
 
 import (
 	"encoding/base64"
+	"fmt"
+	"strings"
 
 	"github.com/pborman/uuid"
 )
@@ -30,4 +32,33 @@ func (a *AccessTokenGenDefault) GenerateAccessToken(data *AccessData, generatere
 		refreshtoken = base64.RawURLEncoding.EncodeToString([]byte(rtoken))
 	}
 	return
+}
+
+// AccessTokenSubScoperDefault checks if the given scopes of AT request are a string subset of already granted scopes.
+type AccessTokenSubScoperDefault struct {
+}
+
+// GenerateAccessToken generates base64-encoded UUID access and refresh tokens
+func (a *AccessTokenSubScoperDefault) CheckSubScopes(requestedScopes string, grantedScopes string) (resultingScope string, err error) {
+	access_scopes_list := strings.Split(requestedScopes, ",")
+	refresh_scopes_list := strings.Split(grantedScopes, ",")
+
+	access_map := make(map[string]int)
+
+	for _, scope := range access_scopes_list {
+		if scope == "" {
+			continue
+		}
+		access_map[scope] = 1
+	}
+
+	for _, scope := range refresh_scopes_list {
+		if scope == "" {
+			continue
+		}
+		if _, ok := access_map[scope]; !ok {
+			return "", fmt.Errorf("scope %v is not in original grant")
+		}
+	}
+	return requestedScopes, nil
 }

--- a/tokengen.go
+++ b/tokengen.go
@@ -39,26 +39,26 @@ type AccessTokenSubScoperDefault struct {
 }
 
 // GenerateAccessToken generates base64-encoded UUID access and refresh tokens
-func (a *AccessTokenSubScoperDefault) CheckSubScopes(requestedScopes string, grantedScopes string) (resultingScope string, err error) {
-	access_scopes_list := strings.Split(requestedScopes, ",")
-	refresh_scopes_list := strings.Split(grantedScopes, ",")
+func (a *AccessTokenSubScoperDefault) CheckSubScopes(accessTokenScopes string, refreshTokenScopes string) (resultingScope string, err error) {
+	refresh_scopes_list := strings.Split(refreshTokenScopes, ",")
+	access_scope_list := strings.Split(accessTokenScopes, ",")
 
-	access_map := make(map[string]int)
-
-	for _, scope := range access_scopes_list {
-		if scope == "" {
-			continue
-		}
-		access_map[scope] = 1
-	}
+	refresh_map := make(map[string]int)
 
 	for _, scope := range refresh_scopes_list {
 		if scope == "" {
 			continue
 		}
-		if _, ok := access_map[scope]; !ok {
+		refresh_map[scope] = 1
+	}
+
+	for _, scope := range access_scope_list {
+		if scope == "" {
+			continue
+		}
+		if _, ok := refresh_map[scope]; !ok {
 			return "", fmt.Errorf("scope %v is not in original grant")
 		}
 	}
-	return requestedScopes, nil
+	return accessTokenScopes, nil
 }

--- a/tokengen_test.go
+++ b/tokengen_test.go
@@ -1,0 +1,25 @@
+package osin
+
+import "testing"
+
+func TestAccessTokenSubScoperDefault(t *testing.T) {
+	scope := &AccessTokenSubScoperDefault{}
+	if out, err := scope.CheckSubScopes("", ""); out != "" || err != nil {
+		t.Fatalf("check sub scopes should not return a match error on empty strings")
+	}
+
+	if out, err := scope.CheckSubScopes("a", ""); out != "" || err == nil {
+		t.Fatalf("check sub scopes returned true with less scopes")
+	}
+
+	if out, err := scope.CheckSubScopes("a,b", "b,a"); out != "a,b" || err != nil {
+		t.Fatalf("check sub scopes returned true with matching scopes %v err %v", out, err)
+	}
+
+	if out, err := scope.CheckSubScopes("a,b", "b,a,c"); out != "a,b" || err != nil {
+		t.Fatalf("check sub scopes returned false with extra scopes")
+	}
+	if out, err := scope.CheckSubScopes("", "a"); out != "" || err != nil {
+		t.Fatalf("check sub scopes returned false with extra scopes")
+	}
+}


### PR DESCRIPTION
This change allows users to override the `scope` subsetting logic of the server, in case they want to provide wildcard matching. 

For example, if the Access Token requests: `user:info`, but the RefreshToken already provides access to `user:*`.

The existing logic `extraScopes` is preserved as the default implementation.