### PR TITLE
Add helpful internal errors.

### DIFF
--- a/util.go
+++ b/util.go
@@ -31,7 +31,8 @@ func CheckClientSecret(client Client, secret string) bool {
 	}
 }
 
-// Return authorization header data
+// CheckBasicAuth returns basic auth information from the request.
+// In case an Authorization header is missing, or parse errors, an error is returned.
 func CheckBasicAuth(r *http.Request) (*BasicAuth, error) {
 	if r.Header.Get("Authorization") == "" {
 		return nil, errors.New("Missing authorization header")

--- a/util.go
+++ b/util.go
@@ -32,10 +32,9 @@ func CheckClientSecret(client Client, secret string) bool {
 }
 
 // CheckBasicAuth returns basic auth information from the request.
-// In case an Authorization header is missing, or parse errors, an error is returned.
 func CheckBasicAuth(r *http.Request) (*BasicAuth, error) {
 	if r.Header.Get("Authorization") == "" {
-		return nil, errors.New("Missing authorization header")
+		return nil, nil
 	}
 
 	s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)

--- a/util.go
+++ b/util.go
@@ -34,7 +34,7 @@ func CheckClientSecret(client Client, secret string) bool {
 // Return authorization header data
 func CheckBasicAuth(r *http.Request) (*BasicAuth, error) {
 	if r.Header.Get("Authorization") == "" {
-		return nil, nil
+		return nil, errors.New("Missing authorization header")
 	}
 
 	s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)

--- a/util_test.go
+++ b/util_test.go
@@ -16,7 +16,7 @@ func TestBasicAuth(t *testing.T) {
 	r := &http.Request{Header: make(http.Header)}
 
 	// Without any header
-	if b, err := CheckBasicAuth(r); b != nil || err != nil {
+	if b, err := CheckBasicAuth(r); b != nil || err == nil {
 		t.Errorf("Validated basic auth without header")
 	}
 

--- a/util_test.go
+++ b/util_test.go
@@ -16,7 +16,7 @@ func TestBasicAuth(t *testing.T) {
 	r := &http.Request{Header: make(http.Header)}
 
 	// Without any header
-	if b, err := CheckBasicAuth(r); b != nil || err == nil {
+	if b, err := CheckBasicAuth(r); b != nil || err != nil {
 		t.Errorf("Validated basic auth without header")
 	}
 


### PR DESCRIPTION
This PR improves debuggability of `osin` by adding an `InternalError` to common missing parameters. 

These errors (except for required URL parameters: `code`, `refresh_token`) are *not* surfaced to the users and are just added as an `InternalError` for the caller to operate on (e.g. log).

