### PR TITLE
add Context support for storage in a backwards compatible manner.

### DIFF
--- a/access.go
+++ b/access.go
@@ -180,13 +180,13 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 	}
 
 	// must have a valid client
-	if ret.Client = getClient(ctx, auth, w.storage(), w); ret.Client == nil {
+	if ret.Client = getClient(ctx, auth, w.GetStorage(), w); ret.Client == nil {
 		return nil
 	}
 
 	// must be a valid authorization code
 	var err error
-	ret.AuthorizeData, err = w.storage().LoadAuthorize(ctx, ret.Code)
+	ret.AuthorizeData, err = w.GetStorage().LoadAuthorize(ctx, ret.Code)
 	if err != nil {
 		w.SetError(E_INVALID_GRANT, "")
 		w.InternalError = err
@@ -315,13 +315,13 @@ func (s *Server) handleRefreshTokenRequest(w *Response, r *http.Request) *Access
 	}
 
 	// must have a valid client
-	if ret.Client = getClient(ctx, auth, w.storage(), w); ret.Client == nil {
+	if ret.Client = getClient(ctx, auth, w.GetStorage(), w); ret.Client == nil {
 		return nil
 	}
 
 	// must be a valid refresh code
 	var err error
-	ret.AccessData, err = w.storage().LoadRefresh(ctx, ret.Code)
+	ret.AccessData, err = w.GetStorage().LoadRefresh(ctx, ret.Code)
 	if err != nil {
 		w.SetError(E_INVALID_GRANT, "")
 		w.InternalError = err
@@ -390,7 +390,7 @@ func (s *Server) handlePasswordRequest(w *Response, r *http.Request) *AccessRequ
 	}
 
 	// must have a valid client
-	if ret.Client = getClient(ctx, auth, w.storage(), w); ret.Client == nil {
+	if ret.Client = getClient(ctx, auth, w.GetStorage(), w); ret.Client == nil {
 		return nil
 	}
 
@@ -418,7 +418,7 @@ func (s *Server) handleClientCredentialsRequest(w *Response, r *http.Request) *A
 	}
 
 	// must have a valid client
-	if ret.Client = getClient(ctx, auth, w.storage(), w); ret.Client == nil {
+	if ret.Client = getClient(ctx, auth, w.GetStorage(), w); ret.Client == nil {
 		return nil
 	}
 
@@ -454,7 +454,7 @@ func (s *Server) handleAssertionRequest(w *Response, r *http.Request) *AccessReq
 	}
 
 	// must have a valid client
-	if ret.Client = getClient(ctx, auth, w.storage(), w); ret.Client == nil {
+	if ret.Client = getClient(ctx, auth, w.GetStorage(), w); ret.Client == nil {
 		return nil
 	}
 
@@ -504,7 +504,7 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 		}
 
 		// save access token
-		if err = w.storage().SaveAccess(ctx, ret); err != nil {
+		if err = w.GetStorage().SaveAccess(ctx, ret); err != nil {
 			w.SetError(E_SERVER_ERROR, "")
 			w.InternalError = err
 			return
@@ -512,15 +512,15 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 
 		// remove authorization token
 		if ret.AuthorizeData != nil {
-			w.storage().RemoveAuthorize(ctx, ret.AuthorizeData.Code)
+			w.GetStorage().RemoveAuthorize(ctx, ret.AuthorizeData.Code)
 		}
 
 		// remove previous access token
 		if ret.AccessData != nil {
 			if ret.AccessData.RefreshToken != "" {
-				w.storage().RemoveRefresh(ctx, ret.AccessData.RefreshToken)
+				w.GetStorage().RemoveRefresh(ctx, ret.AccessData.RefreshToken)
 			}
-			w.storage().RemoveAccess(ctx, ret.AccessData.AccessToken)
+			w.GetStorage().RemoveAccess(ctx, ret.AccessData.AccessToken)
 		}
 
 		// output data

--- a/access_test.go
+++ b/access_test.go
@@ -357,7 +357,7 @@ func TestAccessAuthorizationCodePKCE(t *testing.T) {
 		sconfig.AllowedAccessTypes = AllowedAccessType{AUTHORIZATION_CODE}
 		server := NewServer(sconfig, testStorage)
 		server.AccessTokenGen = &TestingAccessTokenGen{}
-		server.storage().SaveAuthorize(context.TODO(), &AuthorizeData{
+		server.GetStorage().SaveAuthorize(context.TODO(), &AuthorizeData{
 			Client:              testStorage.clients["public-client"],
 			Code:                "pkce-code",
 			ExpiresIn:           3600,

--- a/authorize.go
+++ b/authorize.go
@@ -124,7 +124,7 @@ func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *Authorize
 	}
 
 	// must have a valid client
-	ret.Client, err = w.storage().GetClient(ctx, r.Form.Get("client_id"))
+	ret.Client, err = w.GetStorage().GetClient(ctx, r.Form.Get("client_id"))
 	if err != nil {
 		w.SetErrorState(E_SERVER_ERROR, "", ret.State)
 		w.InternalError = err
@@ -256,7 +256,7 @@ func (s *Server) FinishAuthorizeRequest(w *Response, r *http.Request, ar *Author
 			ret.Code = code
 
 			// save authorization token
-			if err = w.storage().SaveAuthorize(ctx, ret); err != nil {
+			if err = w.GetStorage().SaveAuthorize(ctx, ret); err != nil {
 				w.SetErrorState(E_SERVER_ERROR, "", ar.State)
 				w.InternalError = err
 				return

--- a/authorize.go
+++ b/authorize.go
@@ -104,6 +104,7 @@ type AuthorizeTokenGen interface {
 // HandleAuthorizeRequest is the main http.HandlerFunc for handling
 // authorization requests
 func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *AuthorizeRequest {
+	ctx := contextFromRequest(r)
 	r.ParseForm()
 
 	// create the authorization request
@@ -123,7 +124,7 @@ func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *Authorize
 	}
 
 	// must have a valid client
-	ret.Client, err = w.Storage.GetClient(r.Form.Get("client_id"))
+	ret.Client, err = w.storage().GetClient(ctx, r.Form.Get("client_id"))
 	if err != nil {
 		w.SetErrorState(E_SERVER_ERROR, "", ret.State)
 		w.InternalError = err
@@ -200,6 +201,7 @@ func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *Authorize
 }
 
 func (s *Server) FinishAuthorizeRequest(w *Response, r *http.Request, ar *AuthorizeRequest) {
+	ctx := contextFromRequest(r)
 	// don't process if is already an error
 	if w.IsError {
 		return
@@ -254,7 +256,7 @@ func (s *Server) FinishAuthorizeRequest(w *Response, r *http.Request, ar *Author
 			ret.Code = code
 
 			// save authorization token
-			if err = w.Storage.SaveAuthorize(ret); err != nil {
+			if err = w.storage().SaveAuthorize(ctx, ret); err != nil {
 				w.SetErrorState(E_SERVER_ERROR, "", ar.State)
 				w.InternalError = err
 				return

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -190,7 +190,7 @@ func TestAuthorizeCodePKCEPlain(t *testing.T) {
 		t.Fatalf("Unexpected authorization code: %s", code)
 	}
 
-	token, err := server.storage().LoadAuthorize(context.TODO(), code)
+	token, err := server.GetStorage().LoadAuthorize(context.TODO(), code)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -246,7 +246,7 @@ func TestAuthorizeCodePKCES256(t *testing.T) {
 		t.Fatalf("Unexpected authorization code: %s", code)
 	}
 
-	token, err := server.storage().LoadAuthorize(context.TODO(), code)
+	token, err := server.GetStorage().LoadAuthorize(context.TODO(), code)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/authorize_test.go
+++ b/authorize_test.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestAuthorizeCode(t *testing.T) {
@@ -188,7 +190,7 @@ func TestAuthorizeCodePKCEPlain(t *testing.T) {
 		t.Fatalf("Unexpected authorization code: %s", code)
 	}
 
-	token, err := server.Storage.LoadAuthorize(code)
+	token, err := server.storage().LoadAuthorize(context.TODO(), code)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -244,7 +246,7 @@ func TestAuthorizeCodePKCES256(t *testing.T) {
 		t.Fatalf("Unexpected authorization code: %s", code)
 	}
 
-	token, err := server.Storage.LoadAuthorize(code)
+	token, err := server.storage().LoadAuthorize(context.TODO(), code)
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}

--- a/context_go16.go
+++ b/context_go16.go
@@ -1,0 +1,13 @@
+// +build !go1.7
+
+package osin
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+func contextFromRequest(req *http.Request) context.Context {
+	return context.TODO()
+}

--- a/context_go17.go
+++ b/context_go17.go
@@ -1,0 +1,13 @@
+// +build go1.7
+
+package osin
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+func contextFromRequest(req *http.Request) context.Context {
+	return req.Context()
+}

--- a/info.go
+++ b/info.go
@@ -14,6 +14,7 @@ type InfoRequest struct {
 // HandleInfoRequest is an http.HandlerFunc for server information
 // NOT an RFC specification.
 func (s *Server) HandleInfoRequest(w *Response, r *http.Request) *InfoRequest {
+	ctx := contextFromRequest(r)
 	r.ParseForm()
 	bearer := CheckBearerAuth(r)
 	if bearer == nil {
@@ -34,7 +35,7 @@ func (s *Server) HandleInfoRequest(w *Response, r *http.Request) *InfoRequest {
 	var err error
 
 	// load access data
-	ret.AccessData, err = w.Storage.LoadAccess(ret.Code)
+	ret.AccessData, err = w.storage().LoadAccess(ctx, ret.Code)
 	if err != nil {
 		w.SetError(E_INVALID_REQUEST, "")
 		w.InternalError = err

--- a/info.go
+++ b/info.go
@@ -35,7 +35,7 @@ func (s *Server) HandleInfoRequest(w *Response, r *http.Request) *InfoRequest {
 	var err error
 
 	// load access data
-	ret.AccessData, err = w.storage().LoadAccess(ctx, ret.Code)
+	ret.AccessData, err = w.GetStorage().LoadAccess(ctx, ret.Code)
 	if err != nil {
 		w.SetError(E_INVALID_REQUEST, "")
 		w.InternalError = err

--- a/response.go
+++ b/response.go
@@ -40,18 +40,26 @@ type Response struct {
 }
 
 func NewResponse(storage Storage) *Response {
-	return NewResponseWithContext(&oldStorageWithContext{storage})
+	r := newResponse()
+	r.Storage = storage.Clone()
+	r.StorageWithContext = &oldStorageWithContext{r.Storage}
+	return r
 }
 
 func NewResponseWithContext(storage StorageWithContext) *Response {
+	r := newResponse()
+	r.StorageWithContext = storage.Clone(context.TODO())
+	return r
+}
+
+func newResponse() *Response {
 	r := &Response{
-		Type:               DATA,
-		StatusCode:         200,
-		ErrorStatusCode:    200,
-		Output:             make(ResponseData),
-		Headers:            make(http.Header),
-		IsError:            false,
-		StorageWithContext: storage.Clone(context.TODO()),
+		Type:            DATA,
+		StatusCode:      200,
+		ErrorStatusCode: 200,
+		Output:          make(ResponseData),
+		Headers:         make(http.Header),
+		IsError:         false,
 	}
 	r.Headers.Add(
 		"Cache-Control",
@@ -62,7 +70,7 @@ func NewResponseWithContext(storage StorageWithContext) *Response {
 	return r
 }
 
-// GetStorage is a getter for the clone of the StorageWithContext associated with the Response.
+// GetStorage is a getter for the StorageWithContext associated with the Response.
 func (r *Response) GetStorage() StorageWithContext {
 	if r.StorageWithContext == nil {
 		return &oldStorageWithContext{Storage: r.Storage}

--- a/response.go
+++ b/response.go
@@ -62,7 +62,8 @@ func NewResponseWithContext(storage StorageWithContext) *Response {
 	return r
 }
 
-func (r *Response) storage() StorageWithContext {
+// GetStorage is a getter for the clone of the StorageWithContext associated with the Response.
+func (r *Response) GetStorage() StorageWithContext {
 	if r.StorageWithContext == nil {
 		return &oldStorageWithContext{Storage: r.Storage}
 	}
@@ -161,5 +162,5 @@ func (r *Response) GetRedirectUrl() (string, error) {
 }
 
 func (r *Response) Close() {
-	r.storage().Close()
+	r.GetStorage().Close()
 }

--- a/server.go
+++ b/server.go
@@ -16,7 +16,9 @@ type Server struct {
 
 // NewServer creates a new server instance
 func NewServer(config *ServerConfig, storage Storage) *Server {
-	return NewServerWithContext(config, &oldStorageWithContext{storage})
+	s := NewServerWithContext(config, &oldStorageWithContext{storage})
+	s.Storage = storage
+	return s
 }
 
 // NewServerWithContext creates a new server instance that has a context-aware storage.

--- a/server.go
+++ b/server.go
@@ -32,12 +32,13 @@ func NewServerWithContext(config *ServerConfig, storage StorageWithContext) *Ser
 
 // NewResponse creates a new response for the server
 func (s *Server) NewResponse() *Response {
-	r := NewResponseWithContext(s.storage())
+	r := NewResponseWithContext(s.GetStorage())
 	r.ErrorStatusCode = s.Config.ErrorStatusCode
 	return r
 }
 
-func (s *Server) storage() StorageWithContext {
+// GetStorage is a getter for the StorageWithContext associated with the Server.
+func (s *Server) GetStorage() StorageWithContext {
 	if s.StorageWithContext == nil {
 		return &oldStorageWithContext{Storage: s.Storage}
 	}

--- a/server.go
+++ b/server.go
@@ -6,27 +6,40 @@ import (
 
 // Server is an OAuth2 implementation
 type Server struct {
-	Config            *ServerConfig
-	Storage           Storage
-	AuthorizeTokenGen AuthorizeTokenGen
-	AccessTokenGen    AccessTokenGen
-	Now               func() time.Time
+	Config             *ServerConfig
+	Storage            Storage // deprecated in favor of StorageWithContext
+	StorageWithContext StorageWithContext
+	AuthorizeTokenGen  AuthorizeTokenGen
+	AccessTokenGen     AccessTokenGen
+	Now                func() time.Time
 }
 
 // NewServer creates a new server instance
 func NewServer(config *ServerConfig, storage Storage) *Server {
+	return NewServerWithContext(config, &oldStorageWithContext{storage})
+}
+
+// NewServerWithContext creates a new server instance that has a context-aware storage.
+func NewServerWithContext(config *ServerConfig, storage StorageWithContext) *Server {
 	return &Server{
-		Config:            config,
-		Storage:           storage,
-		AuthorizeTokenGen: &AuthorizeTokenGenDefault{},
-		AccessTokenGen:    &AccessTokenGenDefault{},
-		Now:               time.Now,
+		Config:             config,
+		StorageWithContext: storage,
+		AuthorizeTokenGen:  &AuthorizeTokenGenDefault{},
+		AccessTokenGen:     &AccessTokenGenDefault{},
+		Now:                time.Now,
 	}
 }
 
 // NewResponse creates a new response for the server
 func (s *Server) NewResponse() *Response {
-	r := NewResponse(s.Storage)
+	r := NewResponseWithContext(s.storage())
 	r.ErrorStatusCode = s.Config.ErrorStatusCode
 	return r
+}
+
+func (s *Server) storage() StorageWithContext {
+	if s.StorageWithContext == nil {
+		return &oldStorageWithContext{Storage: s.Storage}
+	}
+	return s.StorageWithContext
 }

--- a/storage.go
+++ b/storage.go
@@ -1,6 +1,6 @@
 package osin
 
-import ()
+import "golang.org/x/net/context"
 
 // Storage interface
 type Storage interface {
@@ -46,4 +46,94 @@ type Storage interface {
 
 	// RemoveRefresh revokes or deletes refresh AccessData.
 	RemoveRefresh(token string) error
+}
+
+// Storage interface that takes a context object for database operations.
+type StorageWithContext interface {
+	// Clone the storage if needed. For example, using mgo, you can clone the session with session.Clone
+	// to avoid concurrent access problems.
+	// This is to avoid cloning the connection at each method access.
+	// Can return itself if not a problem.
+	Clone(ctx context.Context) StorageWithContext
+
+	// Close the resources the Storage potentially holds (using Clone for example)
+	Close()
+
+	// GetClient loads the client by id (client_id)
+	GetClient(ctx context.Context, id string) (Client, error)
+
+	// SaveAuthorize saves authorize data.
+	SaveAuthorize(ctx context.Context, data *AuthorizeData) error
+
+	// LoadAuthorize looks up AuthorizeData by a code.
+	// Client information MUST be loaded together.
+	// Optionally can return error if expired.
+	LoadAuthorize(ctx context.Context, code string) (*AuthorizeData, error)
+
+	// RemoveAuthorize revokes or deletes the authorization code.
+	RemoveAuthorize(ctx context.Context, code string) error
+
+	// SaveAccess writes AccessData.
+	// If RefreshToken is not blank, it must save in a way that can be loaded using LoadRefresh.
+	SaveAccess(ctx context.Context, data *AccessData) error
+
+	// LoadAccess retrieves access data by token. Client information MUST be loaded together.
+	// AuthorizeData and AccessData DON'T NEED to be loaded if not easily available.
+	// Optionally can return error if expired.
+	LoadAccess(ctx context.Context, token string) (*AccessData, error)
+
+	// RemoveAccess revokes or deletes an AccessData.
+	RemoveAccess(ctx context.Context, token string) error
+
+	// LoadRefresh retrieves refresh AccessData. Client information MUST be loaded together.
+	// AuthorizeData and AccessData DON'T NEED to be loaded if not easily available.
+	// Optionally can return error if expired.
+	LoadRefresh(ctx context.Context, token string) (*AccessData, error)
+
+	// RemoveRefresh revokes or deletes refresh AccessData.
+	RemoveRefresh(ctx context.Context, token string) error
+}
+
+type oldStorageWithContext struct {
+	Storage
+}
+
+func (s *oldStorageWithContext) Clone(ctx context.Context) StorageWithContext {
+	return &oldStorageWithContext{Storage: s.Storage.Clone()}
+}
+
+func (s *oldStorageWithContext) GetClient(ctx context.Context, id string) (Client, error) {
+	return s.Storage.GetClient(id)
+}
+
+func (s *oldStorageWithContext) SaveAuthorize(ctx context.Context, data *AuthorizeData) error {
+	return s.Storage.SaveAuthorize(data)
+}
+
+func (s *oldStorageWithContext) LoadAuthorize(ctx context.Context, code string) (*AuthorizeData, error) {
+	return s.Storage.LoadAuthorize(code)
+}
+
+func (s *oldStorageWithContext) RemoveAuthorize(ctx context.Context, code string) error {
+	return s.Storage.RemoveAuthorize(code)
+}
+
+func (s *oldStorageWithContext) SaveAccess(ctx context.Context, access *AccessData) error {
+	return s.Storage.SaveAccess(access)
+}
+
+func (s *oldStorageWithContext) LoadAccess(ctx context.Context, token string) (*AccessData, error) {
+	return s.Storage.LoadAccess(token)
+}
+
+func (s *oldStorageWithContext) RemoveAccess(ctx context.Context, token string) error {
+	return s.Storage.RemoveAccess(token)
+}
+
+func (s *oldStorageWithContext) LoadRefresh(ctx context.Context, token string) (*AccessData, error) {
+	return s.Storage.LoadRefresh(token)
+}
+
+func (s *oldStorageWithContext) RemoveRefresh(ctx context.Context, token string) error {
+	return s.Storage.RemoveRefresh(token)
 }


### PR DESCRIPTION
This fixes https://github.com/RangelReale/osin/issues/139

Basically this allows `context.Context` of `http.Request` to be propagaded to the Backend. If your server has a deadlien for requests, this means that your storage will obey these requests (e.g. deadlines, cancellation).

We currently need it for Go 1.7, since we have a `Storage`  relying on Google Datastore (which uses gRPC and Context cancellation). For Go 1.8 the `database/sql` packages will support cancellable queries: https://tylerchr.blog/golang-18-whats-coming/


This change adds `StorageWithContext` to avoid breaking compatibility with users implementing `Storage`. If a `Storage` is used, a `StorageWithContext` adapter is used.