### PR TITLE
Custom extraScopes

### DIFF
--- a/access.go
+++ b/access.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -262,30 +261,6 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 	return ret
 }
 
-func extraScopes(access_scopes, refresh_scopes string) bool {
-	access_scopes_list := strings.Split(access_scopes, ",")
-	refresh_scopes_list := strings.Split(refresh_scopes, ",")
-
-	access_map := make(map[string]int)
-
-	for _, scope := range access_scopes_list {
-		if scope == "" {
-			continue
-		}
-		access_map[scope] = 1
-	}
-
-	for _, scope := range refresh_scopes_list {
-		if scope == "" {
-			continue
-		}
-		if _, ok := access_map[scope]; !ok {
-			return true
-		}
-	}
-	return false
-}
-
 func (s *Server) handleRefreshTokenRequest(w *Response, r *http.Request) *AccessRequest {
 	// get client authentication
 	auth := getClientAuth(w, r, s.Config.AllowClientSecretInParams)
@@ -350,7 +325,7 @@ func (s *Server) handleRefreshTokenRequest(w *Response, r *http.Request) *Access
 		ret.Scope = ret.AccessData.Scope
 	}
 
-	if extraScopes(ret.AccessData.Scope, ret.Scope) {
+	if s.ExtraScopes.CheckScopes(ret.AccessData.Scope, ret.Scope) {
 		w.SetError(E_ACCESS_DENIED, "")
 		w.InternalError = errors.New("the requested scope must not include any scope not originally granted by the resource owner")
 		return nil

--- a/access_test.go
+++ b/access_test.go
@@ -249,29 +249,6 @@ func TestAccessClientCredentials(t *testing.T) {
 	}
 }
 
-func TestExtraScopes(t *testing.T) {
-	if extraScopes("", "") == true {
-		t.Fatalf("extraScopes returned true with empty scopes")
-	}
-
-	if extraScopes("a", "") == true {
-		t.Fatalf("extraScopes returned true with less scopes")
-	}
-
-	if extraScopes("a,b", "b,a") == true {
-		t.Fatalf("extraScopes returned true with matching scopes")
-	}
-
-	if extraScopes("a,b", "b,a,c") == false {
-		t.Fatalf("extraScopes returned false with extra scopes")
-	}
-
-	if extraScopes("", "a") == false {
-		t.Fatalf("extraScopes returned false with extra scopes")
-	}
-
-}
-
 // clientWithoutMatcher just implements the base Client interface
 type clientWithoutMatcher struct {
 	Id          string

--- a/extrascopes.go
+++ b/extrascopes.go
@@ -1,0 +1,36 @@
+package osin
+
+import "strings"
+
+type ExtraScopesDefault struct {
+}
+
+type ExtraScopes interface {
+	CheckScopes(access_scopes, refresh_scopes string) bool
+}
+
+func (e *ExtraScopesDefault) CheckScopes(access_scopes, refresh_scopes string) bool {
+
+	access_scopes_list := strings.Split(access_scopes, ",")
+	refresh_scopes_list := strings.Split(refresh_scopes, ",")
+
+	access_map := make(map[string]int)
+
+	for _, scope := range access_scopes_list {
+		if scope == "" {
+			continue
+		}
+		access_map[scope] = 1
+	}
+
+	for _, scope := range refresh_scopes_list {
+		if scope == "" {
+			continue
+		}
+		if _, ok := access_map[scope]; !ok {
+			return true
+		}
+	}
+	return false
+
+}

--- a/extrascopes_test.go
+++ b/extrascopes_test.go
@@ -1,0 +1,28 @@
+package osin
+
+import "testing"
+
+func TestExtraScopesDefault(t *testing.T) {
+	e := ExtraScopesDefault{}
+
+	if e.CheckScopes("", "") == true {
+		t.Fatalf("e.CheckScopes returned true with empty scopes")
+	}
+
+	if e.CheckScopes("a", "") == true {
+		t.Fatalf("e.CheckScopes returned true with less scopes")
+	}
+
+	if e.CheckScopes("a,b", "b,a") == true {
+		t.Fatalf("e.CheckScopes returned true with matching scopes")
+	}
+
+	if e.CheckScopes("a,b", "b,a,c") == false {
+		t.Fatalf("e.CheckScopes returned false with extra scopes")
+	}
+
+	if e.CheckScopes("", "a") == false {
+		t.Fatalf("e.CheckScopes returned false with extra scopes")
+	}
+
+}

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ type Server struct {
 	Storage           Storage
 	AuthorizeTokenGen AuthorizeTokenGen
 	AccessTokenGen    AccessTokenGen
+	ExtraScopes       ExtraScopes
 	Now               func() time.Time
 }
 
@@ -20,6 +21,7 @@ func NewServer(config *ServerConfig, storage Storage) *Server {
 		Storage:           storage,
 		AuthorizeTokenGen: &AuthorizeTokenGenDefault{},
 		AccessTokenGen:    &AccessTokenGenDefault{},
+		ExtraScopes:       &ExtraScopesDefault{},
 		Now:               time.Now,
 	}
 }


### PR DESCRIPTION
The RFC states in section 6:

> The requested scope MUST NOT include any scope not originally granted by the resource owner, and if omitted is treated as equal to the scope originally granted by the resource owner.

However, this can be tricky if you use custom semantic scopes. For example, assume a scope looks like: permissions:read,write, it may make sense to allow a refresh to grant permissions:read as it's technically the same or less permissions and is not an additional scope. 

Currently, Osin enforces this by doing straight string comparison. This PR allows a developer to create a custom compare function that handles strange custom cases as described above while defaulting to a DefaultExtraScopes that uses the current behavior.