### PR TITLE
fix: on invalid_client response, the HTTP status code MUST be 401, an…

### DIFF
--- a/access.go
+++ b/access.go
@@ -537,12 +537,12 @@ func (s Server) getClient(auth *BasicAuth, storage Storage, w *Response) Client 
 		return nil
 	}
 	if client == nil {
-		s.setErrorAndLog(w, E_UNAUTHORIZED_CLIENT, nil, "get_client=%s", "client is nil")
+		s.setErrorAndLog(w, E_INVALID_CLIENT, nil, "get_client=%s", "client is nil")
 		return nil
 	}
 
 	if !CheckClientSecret(client, auth.Password) {
-		s.setErrorAndLog(w, E_UNAUTHORIZED_CLIENT, nil, "get_client=%s, client_id=%v", "client check failed", client.GetId())
+		s.setErrorAndLog(w, E_INVALID_CLIENT, nil, "get_client=%s, client_id=%v", "client check failed", client.GetId())
 		return nil
 	}
 

--- a/response_json.go
+++ b/response_json.go
@@ -27,6 +27,11 @@ func OutputJSON(rs *Response, w http.ResponseWriter, r *http.Request) error {
 		if w.Header().Get("Content-Type") == "" {
 			w.Header().Set("Content-Type", "application/json")
 		}
+
+		if rs.ErrorId == E_INVALID_CLIENT && r.Header.Get("Authorization") != "" {
+			rs.StatusCode = http.StatusUnauthorized // as described here https://tools.ietf.org/html/rfc6749#section-5.2
+		}
+
 		w.WriteHeader(rs.StatusCode)
 
 		encoder := json.NewEncoder(w)


### PR DESCRIPTION
…d the response must include the www-authenticate header

https://tools.ietf.org/html/rfc6749#section-5.2