### PR TITLE
Error handling for remove authorize, refresh and access tokens

### DIFF
--- a/access.go
+++ b/access.go
@@ -494,15 +494,27 @@ func (s *Server) FinishAccessRequest(w *Response, r *http.Request, ar *AccessReq
 
 		// remove authorization token
 		if ret.AuthorizeData != nil {
-			w.Storage.RemoveAuthorize(ret.AuthorizeData.Code)
+			err = w.Storage.RemoveAuthorize(ret.AuthorizeData.Code)
+			if err != nil {
+				s.setErrorAndLog(w, E_SERVER_ERROR, err, "finish_access_request=%s", "error removing authorize token")
+				return
+			}
 		}
 
 		// remove previous access token
 		if ret.AccessData != nil && !s.Config.RetainTokenAfterRefresh {
 			if ret.AccessData.RefreshToken != "" {
-				w.Storage.RemoveRefresh(ret.AccessData.RefreshToken)
+				err = w.Storage.RemoveRefresh(ret.AccessData.RefreshToken)
+				if err != nil {
+					s.setErrorAndLog(w, E_SERVER_ERROR, err, "finish_access_request=%s", "error removing refresh token")
+					return
+				}
 			}
-			w.Storage.RemoveAccess(ret.AccessData.AccessToken)
+			err = w.Storage.RemoveAccess(ret.AccessData.AccessToken)
+			if err != nil {
+				s.setErrorAndLog(w, E_SERVER_ERROR, err, "finish_access_request=%s", "error removing access token")
+				return
+			}
 		}
 
 		// output data


### PR DESCRIPTION
It's not handling the errors during the RemoveAuthorize, RemoveRefresh and RemoveAccess operations in the FinishAccessRequest function. When it gets an error in those functions it continues the process without returning or logging the error