### PR TITLE
fix: ServerConfig.AuthorizationExpiration defaults to 5min (300s) but was actually defaulting to 250s

### DIFF
--- a/config.go
+++ b/config.go
@@ -69,7 +69,7 @@ type ServerConfig struct {
 // NewServerConfig returns a new ServerConfig with default configuration
 func NewServerConfig() *ServerConfig {
 	return &ServerConfig{
-		AuthorizationExpiration:   250,
+		AuthorizationExpiration:   300,
 		AccessExpiration:          3600,
 		TokenType:                 "Bearer",
 		AllowedAuthorizeTypes:     AllowedAuthorizeType{CODE},


### PR DESCRIPTION
The docs note 

```
type ServerConfig struct {  
    // Authorization token expiration in seconds (default 5 minutes)
    AuthorizationExpiration int32
```

but it was actually defaulting to 250s.

This commit sets the default value of AuthorizationExpiration to 300s