### PR TITLE
Allow forcing PKCE for all clients

### DIFF
--- a/authorize.go
+++ b/authorize.go
@@ -172,6 +172,11 @@ func (s *Server) HandleAuthorizeRequest(w *Response, r *http.Request) *Authorize
 					w.SetErrorState(E_INVALID_REQUEST, "code_challenge (rfc7636) required for public clients", ret.State)
 					return nil
 				}
+				if s.Config.RequirePKCEForAllClients {
+					// https://tools.ietf.org/html/rfc7636#section-4.4.1
+					w.SetErrorState(E_INVALID_REQUEST, "code_challenge (rfc7636) required", ret.State)
+					return nil
+				}
 			} else {
 				codeChallengeMethod := r.FormValue("code_challenge_method")
 				// allowed values are "plain" (default) and "S256", per https://tools.ietf.org/html/rfc7636#section-4.3

--- a/config.go
+++ b/config.go
@@ -57,6 +57,9 @@ type ServerConfig struct {
 	// Require PKCE for code flows for public OAuth clients - default false
 	RequirePKCEForPublicClients bool
 
+	// Require PKCE for code flows for all OAuth clients - default false
+	RequirePKCEForAllClients bool
+
 	// Separator to support multiple URIs in Client.GetRedirectUri().
 	// If blank (the default), don't allow multiple URIs.
 	RedirectUriSeparator string


### PR DESCRIPTION
* adds a configuation paramter to allow forcing PKCE for all clients,
  not just ones that have empty secrets
* this allows for more flexible control over when PKCE is required