### PR TITLE
Do not set path when resolving URL path

### DIFF
--- a/urivalidate.go
+++ b/urivalidate.go
@@ -65,8 +65,8 @@ func ParseUrls(baseUrl, redirectUrl string) (retBaseUrl, retRedirectUrl *url.URL
 	}
 
 	// resolve references to base url
-	retBaseUrl = (&url.URL{Scheme: base.Scheme, Host: host, Path: "/"}).ResolveReference(&url.URL{Path: base.Path})
-	retRedirectUrl = (&url.URL{Scheme: base.Scheme, Host: host, Path: "/"}).ResolveReference(&url.URL{Path: redirect.Path, RawQuery: redirect.RawQuery})
+	retBaseUrl = (&url.URL{Scheme: base.Scheme, Host: host}).ResolveReference(&url.URL{Path: base.Path})
+	retRedirectUrl = (&url.URL{Scheme: base.Scheme, Host: host}).ResolveReference(&url.URL{Path: redirect.Path, RawQuery: redirect.RawQuery})
 	return
 }
 

--- a/urivalidate_test.go
+++ b/urivalidate_test.go
@@ -19,6 +19,18 @@ func TestURIValidate(t *testing.T) {
 			"http://localhost:14000/appauth",
 		},
 		{
+			"Only domain, exact match",
+			"http://google.com",
+			"http://google.com",
+			"http://google.com",
+		},
+		{
+			"Only domain, with subpath",
+			"http://google.com",
+			"http://google.com/redirect",
+			"http://google.com/redirect",
+		},
+		{
 			"Trailing slash",
 			"http://www.google.com/myapp",
 			"http://www.google.com/myapp/",


### PR DESCRIPTION
In `ParseUrls` the input redirect URI is resolved against the register URI and the base path is set to `/`. This introduces a extra `/` in the return value. The change drops the `Path` field and adds tests for the scenario when the registered and input redirect URIs are a domain without a trailing slash. 