### PR TITLE
Regex Support for `redirect_uri`

### DIFF
--- a/access.go
+++ b/access.go
@@ -218,10 +218,6 @@ func (s *Server) handleAuthorizationCodeRequest(w *Response, r *http.Request) *A
 	} else {
 		ret.RedirectUri = realRedirectUri
 	}
-	if ret.AuthorizeData.RedirectUri != ret.RedirectUri {
-		s.setErrorAndLog(w, E_INVALID_REQUEST, errors.New("Redirect uri is different"), "auth_code_request=%s", "client redirect does not match authorization data")
-		return nil
-	}
 
 	// Verify PKCE, if present in the authorization data
 	if len(ret.AuthorizeData.CodeChallenge) > 0 {

--- a/urivalidate.go
+++ b/urivalidate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"regexp"
 	"strings"
 )
 
@@ -105,7 +106,22 @@ func ValidateUri(baseUri string, redirectUri string) (realRedirectUri string, er
 		return "", errors.New("urls cannot be blank.")
 	}
 
+	if baseUri[0] == '/' && baseUri[len(baseUri)-1] == '/' {
+		matched, err := regexp.MatchString(baseUri[1:len(baseUri)-1], redirectUri)
+
+		if err != nil {
+			return "", err
+		}
+
+		if matched == false {
+			return "", errors.New("redirectURI did not match regex")
+		}
+
+		return redirectUri, nil
+	}
+
 	base, redirect, err := ParseUrls(baseUri, redirectUri)
+
 	if err != nil {
 		return "", err
 	}
@@ -117,6 +133,7 @@ func ValidateUri(baseUri string, redirectUri string) (realRedirectUri string, er
 
 	// ensure prefix matches are actually subpaths
 	requiredPrefix := strings.TrimRight(base.Path, "/") + "/"
+
 	if !strings.HasPrefix(redirect.Path, requiredPrefix) {
 		return "", newUriValidationError("path prefix doesn't match", baseUri, redirectUri)
 	}

--- a/urivalidate_test.go
+++ b/urivalidate_test.go
@@ -108,6 +108,12 @@ func TestURIValidate(t *testing.T) {
 			"http://[0:0:0:0:0:0:0:1]/callback",
 			"http://[0:0:0:0:0:0:0:1]/callback",
 		},
+		{
+			"Regex matches",
+			"/https:\\/\\/google\\.com/(.*)/",
+			"https://google.com/demo",
+			"https://google.com/demo",
+		},
 	}
 	for _, v := range valid {
 		t.Run(fmt.Sprintf("valid/%s", v.name), func(t *testing.T) {
@@ -198,6 +204,11 @@ func TestURIValidate(t *testing.T) {
 			"Redirect URI is loopback, input is a domain name without port",
 			"http://127.0.0.1/callback",
 			"http://example.com/callback",
+		},
+		{
+			"Regex doesn't match",
+			"/https:\\/\\/google\\.com/(.*)/",
+			"https://yahoo.com/demo",
 		},
 	}
 	for _, v := range invalid {


### PR DESCRIPTION
Hi,

this PR adds regex support for `redirect_uri` without breaking support for plain URLs (i.e. `https://google.com`) as they will only be compiled as a regex if a client returns a `redirect_uri` that's prefixed and suffixed with `/` (i.e. `/https:\\/\\/google\\.com/(.*)/`).