### PR TITLE
Fix potential panic in CheckBearerAuth

### DIFF
--- a/util.go
+++ b/util.go
@@ -79,12 +79,12 @@ func CheckBearerAuth(r *http.Request) *BearerAuth {
 	token := authForm
 	if authHeader != "" {
 		s := strings.SplitN(authHeader, " ", 2)
-		if (len(s) != 2 || strings.ToLower(s[0]) != "bearer") && token == "" {
-			return nil
+		if len(s) == 2 && strings.ToLower(s[0]) == "bearer" {
+			token = s[1]
 		}
 		//Use authorization header token only if token type is bearer else query string access token would be returned
-		if len(s) > 0 && strings.ToLower(s[0]) == "bearer" {
-			token = s[1]
+		if token == "" {
+			return nil
 		}
 	}
 	return &BearerAuth{Code: token}

--- a/util_test.go
+++ b/util_test.go
@@ -11,6 +11,7 @@ const (
 	badUsernameInAuthValue = "Basic dSUyc2VybmFtZTpwYXNzd29yZA==" // u%2sername:password
 	badPasswordInAuthValue = "Basic dXNlcm5hbWU6cGElMnN3b3Jk"     // username:pa%2sword
 	goodAuthValue          = "Basic Y2xpZW50K25hbWU6Y2xpZW50KyUyNGVjcmV0"
+	badBearerAuthValue     = "Bearer"
 	goodBearerAuthValue    = "Bearer BGFVTDUJDp0ZXN0"
 )
 
@@ -151,6 +152,20 @@ func TestBearerAuth(t *testing.T) {
 	r = &http.Request{URL: url}
 	r.ParseForm()
 	b = CheckBearerAuth(r)
+	if b.Code != "XYZ" {
+		t.Errorf("Error decoding bearer auth")
+	}
+
+	// with valid auth in query and invalid in header
+	url, _ = url.Parse("http://host.tld/path?code=XYZ")
+	r = &http.Request{URL: url, Header: make(http.Header)}
+	r.Header.Set("Authorization", badBearerAuthValue)
+	r.ParseForm()
+	b = CheckBearerAuth(r)
+	if b == nil {
+		t.Errorf("Could not extract bearer auth")
+		return
+	}
 	if b.Code != "XYZ" {
 		t.Errorf("Error decoding bearer auth")
 	}


### PR DESCRIPTION
This PR fixes a panic in `CheckBearerAuth` when providing valid code in the query string and an invalid, empty bearer token in the header.